### PR TITLE
Don't pin node-icu-charset-detector

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   },
   "optionalDependencies": {
     "iconv": "~2.1.6",
-    "node-icu-charset-detector": "0.1.0"
+    "node-icu-charset-detector": "^0.1.0"
   },
   "devDependencies": {
     "faucet": "0.0.1",


### PR DESCRIPTION
Version 0.1.0 is incompatible with nodejs 4. Version 0.1.1 uses newer NaN APIs, supporting both old and new nodejs.