### PR TITLE
Initial hack at busting RFC 3484 sort order

### DIFF
--- a/lib/irc.js
+++ b/lib/irc.js
@@ -28,8 +28,6 @@ var colors = require('./colors');
 var parseMessage = require('./parse_message');
 exports.colors = colors;
 
-var shuffleList = require('shuffle-list');
-
 var lineDelimiter = new RegExp('\r\n|\r|\n')
 
 function Client(server, nick, opt) {
@@ -812,13 +810,17 @@ Client.prototype.connect = function(retryCount, callback) {
                     }
                 }
 
-                addresses = shuffleList(addresses);
-
                 if (options.all) {
-                    callback(err, addresses);
+                    var shuffled = [];
+                    while (addresses.length) {
+                        var i = randomInt(addresses.length);
+                        shuffled.push(addresses.splice(i, 1)[0]);
+                    }
+                    callback(err, shuffled);
                 }
                 else {
-                    callback(err, addresses[0].address, addresses[0].family);
+                    var chosen = addresses[randomInt(addresses.length)];
+                    callback(err, chosen.address, chosen.family);
                 }
             });
         };
@@ -1295,4 +1297,8 @@ Client.prototype._toLowerCase = function(str) {
 // https://developer.mozilla.org/en/docs/Web/JavaScript/Guide/Regular_Expressions
 function escapeRegExp(string){
   return string.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"); // $& means the whole matched string
+}
+
+function randomInt(length) {
+    return Math.floor(Math.random() * length);
 }

--- a/lib/irc.js
+++ b/lib/irc.js
@@ -18,6 +18,7 @@
 */
 
 exports.Client = Client;
+var dns  = require('dns');
 var net  = require('net');
 var tls  = require('tls');
 var util = require('util');
@@ -26,6 +27,8 @@ var EventEmitter = require('events').EventEmitter;
 var colors = require('./colors');
 var parseMessage = require('./parse_message');
 exports.colors = colors;
+
+var shuffleList = require('shuffle-list');
 
 var lineDelimiter = new RegExp('\r\n|\r|\n')
 
@@ -39,6 +42,7 @@ function Client(server, nick, opt) {
         realName: 'nodeJS IRC client',
         port: 6667,
         family: 4,
+        bustRfc3484: false,
         localAddress: null,
         localPort: null,
         debug: false,
@@ -786,6 +790,39 @@ Client.prototype.connect = function(retryCount, callback) {
         connectionOpts.localAddress = self.opt.localAddress;
     if (self.opt.localPort)
         connectionOpts.localPort = self.opt.localPort;
+
+    if (self.opt.bustRfc3484) {
+        // RFC 3484 attempts to sort address results by "locallity", taking
+        //   into consideration the length of the common prefix between the
+        //   candidate local source address and the destination. In practice
+        //   this always sorts one or two servers ahead of all the rest, which
+        //   isn't what we want for proper load balancing. With this option set
+        //   we'll randomise the list of all results so that we can spread load
+        //   between all the servers.
+        connectionOpts.lookup = function(hostname, options, callback) {
+            var optionsWithAll = Object.assign({all: true}, options);
+
+            dns.lookup(hostname, optionsWithAll, (err, addresses) => {
+                if (err) {
+                    if (options.all) {
+                        return callback(err, addresses);
+                    }
+                    else {
+                        return callback(err, null, null);
+                    }
+                }
+
+                addresses = shuffleList(addresses);
+
+                if (options.all) {
+                    callback(err, addresses);
+                }
+                else {
+                    callback(err, addresses[0].address, addresses[0].family);
+                }
+            });
+        };
+    }
 
     // try to connect to the server
     if (self.opt.secure) {

--- a/package.json
+++ b/package.json
@@ -23,8 +23,7 @@
   },
   "license": "GPL-3.0",
   "dependencies": {
-    "irc-colors": "^1.1.0",
-    "shuffle-list": "^1.0.0"
+    "irc-colors": "^1.1.0"
   },
   "optionalDependencies": {
     "iconv": "~2.1.6",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
   },
   "license": "GPL-3.0",
   "dependencies": {
-    "irc-colors": "^1.1.0"
+    "irc-colors": "^1.1.0",
+    "shuffle-list": "^1.0.0"
   },
   "optionalDependencies": {
     "iconv": "~2.1.6",


### PR DESCRIPTION
RFC 3484 specifies a client-side sorting order to apply to DNS results before making `connect()` attempts. Because of this sorting order, it turns out we always pick just one or two of Freenode's IPv6 candidates, instead of spreading the load uniformly and randomly among them.

This patch adds a boolean option, `bustRfc3484` that randomizes the DNS results before making the connection attempt, defeating this mechanism and allowing the connections to be spread more randomly around all the capable servers.