### PR TITLE
Fix parsing of code 319 (whoischannels) reply.

### DIFF
--- a/lib/irc.js
+++ b/lib/irc.js
@@ -461,7 +461,8 @@ function Client(server, nick, opt) {
                 break;
             case 'rpl_whoischannels':
                // TODO - clean this up?
-                self._addWhoisData(message.args[1], 'channels', message.args[2].trim().split(/\s+/));
+                if (message.args.length >= 3)
+                    self._addWhoisData(message.args[1], 'channels', message.args[2].trim().split(/\s+/));
                 break;
             case 'rpl_whoisserver':
                 self._addWhoisData(message.args[1], 'server', message.args[2]);


### PR DESCRIPTION
Some IRC servers return less than 3 arguments with `319` reply.
This change prevents crash when working with these servers.