### PR TITLE
Fix a memory leak in the client to allow it to be GCed

### DIFF
--- a/lib/irc.js
+++ b/lib/irc.js
@@ -977,7 +977,9 @@ Client.prototype.disconnect = function(message, callback) {
         self.conn.once('end', callback);
     }
     self.conn.end();
-    clearInterval(self._floodIntervalId);
+    if (self._floodIntervalId) {
+        clearInterval(self._floodIntervalId);
+    }
 };
 
 Client.prototype.send = function(command) {

--- a/lib/irc.js
+++ b/lib/irc.js
@@ -977,6 +977,7 @@ Client.prototype.disconnect = function(message, callback) {
         self.conn.once('end', callback);
     }
     self.conn.end();
+    clearInterval(self._floodIntervalId);
 };
 
 Client.prototype.send = function(command) {
@@ -1026,7 +1027,7 @@ Client.prototype.activateFloodProtection = function(interval) {
     };
 
     // Slowly unpack the queue without flooding.
-    setInterval(dequeue, safeInterval);
+    this._floodIntervalId = setInterval(dequeue, safeInterval);
     dequeue();
 };
 

--- a/lib/irc.js
+++ b/lib/irc.js
@@ -771,16 +771,12 @@ Client.prototype._connectionHandler = function() {
     this.emit('connect');
 };
 
-function Canary(t) {
-    this.t = t;
-}
-
 Client.prototype.connect = function(retryCount, callback) {
     if (typeof (retryCount) === 'function') {
         callback = retryCount;
         retryCount = undefined;
     }
-    this.retryCount = retryCount || 0;
+    retryCount = retryCount || 0;
     if (typeof (callback) === 'function') {
         this.once('registered', callback);
     }
@@ -893,87 +889,74 @@ Client.prototype.connect = function(retryCount, callback) {
         self.conn.setEncoding('utf8');
     }
 
-    self._buffer = new Buffer('');
-    self._canary = new Canary(Math.random());
-    self._tcpDataListener = self._tcpData.bind(self);
-    self.conn.addListener('data', self._tcpDataListener);
+    var buffer = new Buffer('');
 
-    self._tcpCloseListener = self._tcpClose.bind(self);
-    self.conn.addListener('close', self._tcpCloseListener);
+    self.conn.addListener('data', function(chunk) {
+        if (typeof (chunk) === 'string') {
+            buffer += chunk;
+        } else {
+            buffer = Buffer.concat([buffer, chunk]);
+        }
 
-    self._tcpErrorListener = self._tcpError.bind(self);
-    self.conn.addListener('error', self._tcpErrorListener);
-};
+        var lines = self.convertEncoding(buffer).toString().split(lineDelimiter);
 
-Client.prototype._tcpData = function(chunk) {
-    var self = this;
-    if (self._canary.field === 0.55) {
-        console.log("Canary ", self._canary);
-    }
-    if (typeof (chunk) === 'string') {
-        self._buffer += chunk;
-    } else {
-        self._buffer = Buffer.concat([self._buffer, chunk]);
-    }
+        if (lines.pop()) {
+            // if buffer is not ended with \r\n, there's more chunks.
+            return;
+        } else {
+            // else, initialize the buffer.
+            buffer = new Buffer('');
+        }
 
-    var lines = self.convertEncoding(self._buffer).toString().split(lineDelimiter);
+        lines.forEach(function iterator(line) {
+            if (line.length) {
+                var message = parseMessage(line, self.opt.stripColors);
 
-    if (lines.pop()) {
-        // if buffer is not ended with \r\n, there's more chunks.
-        return;
-    } else {
-        // else, initialize the buffer.
-        self._buffer = new Buffer('');
-    }
-
-    lines.forEach(function iterator(line) {
-        if (line.length) {
-            var message = parseMessage(line, self.opt.stripColors);
-
-            try {
-                self.emit('raw', message);
-            } catch (err) {
-                if (!self.conn.requestedDisconnect) {
-                    throw err;
+                try {
+                    self.emit('raw', message);
+                } catch (err) {
+                    if (!self.conn.requestedDisconnect) {
+                        throw err;
+                    }
                 }
             }
+        });
+    });
+    self.conn.addListener('end', function() {
+        if (self.opt.debug)
+            util.log('Connection got "end" event');
+    });
+    self.conn.addListener('close', function() {
+        if (self.opt.debug)
+            util.log('Connection got "close" event');
+        if (self.conn.requestedDisconnect)
+            return;
+        if (self.opt.debug)
+            util.log('Disconnected: reconnecting');
+        if (self.opt.retryCount !== null && retryCount >= self.opt.retryCount) {
+            if (self.opt.debug) {
+                util.log('Maximum retry count (' + self.opt.retryCount + ') reached. Aborting');
+            }
+            self.emit('abort', self.opt.retryCount);
+            return;
+        }
+
+        if (self.opt.debug) {
+            util.log('Waiting ' + self.opt.retryDelay + 'ms before retrying');
+        }
+        setTimeout(function() {
+            self.connect(retryCount + 1);
+        }, self.opt.retryDelay);
+    });
+    self.conn.addListener('error', function(exception) {
+        self.emit('netError', exception);
+        if (self.opt.debug) {
+            util.log('Network error: ' + exception);
         }
     });
 };
-
-Client.prototype._tcpError = function(exception) {
-    this.emit('netError', exception);
-    if (this.opt.debug) {
-        util.log('Network error: ' + exception);
-    }
-};
-
-Client.prototype._tcpClose = function() {
-    var self = this;
-    if (self.opt.debug)
-        util.log('Connection got "close" event');
-    if (self.conn.requestedDisconnect)
-        return;
-    if (self.opt.debug)
-        util.log('Disconnected: reconnecting');
-    if (self.opt.retryCount !== null && self.retryCount >= self.opt.retryCount) {
-        if (self.opt.debug) {
-            util.log('Maximum retry count (' + self.opt.retryCount + ') reached. Aborting');
-        }
-        self.emit('abort', self.opt.retryCount);
-        return;
-    }
-
-    if (self.opt.debug) {
-        util.log('Waiting ' + self.opt.retryDelay + 'ms before retrying');
-    }
-    setTimeout(function() {
-        self.connect(self.retryCount + 1);
-    }, self.opt.retryDelay);
-};
-
 Client.prototype.disconnect = function(message, callback) {
-    if (typeof (message) === 'fuRnction') {
+    if (typeof (message) === 'function') {
         callback = message;
         message = undefined;
     }
@@ -994,14 +977,6 @@ Client.prototype.disconnect = function(message, callback) {
         self.conn.once('end', callback);
     }
     self.conn.end();
-
-    // cleanup all TCP connection listeners
-    this.removeListener("data", this._tcpDataListener);
-    this.removeListener("error", this._tcpErrorListener);
-    this.removeListener("close", this._tcpCloseListener);
-    this._tcpDataListener = null;
-    this._tcpErrorListener = null;
-    this._tcpCloseListener = null;
 };
 
 Client.prototype.send = function(command) {

--- a/lib/irc.js
+++ b/lib/irc.js
@@ -771,12 +771,16 @@ Client.prototype._connectionHandler = function() {
     this.emit('connect');
 };
 
+function Canary(t) {
+    this.t = t;
+}
+
 Client.prototype.connect = function(retryCount, callback) {
     if (typeof (retryCount) === 'function') {
         callback = retryCount;
         retryCount = undefined;
     }
-    retryCount = retryCount || 0;
+    this.retryCount = retryCount || 0;
     if (typeof (callback) === 'function') {
         this.once('registered', callback);
     }
@@ -889,74 +893,87 @@ Client.prototype.connect = function(retryCount, callback) {
         self.conn.setEncoding('utf8');
     }
 
-    var buffer = new Buffer('');
+    self._buffer = new Buffer('');
+    self._canary = new Canary(Math.random());
+    self._tcpDataListener = self._tcpData.bind(self);
+    self.conn.addListener('data', self._tcpDataListener);
 
-    self.conn.addListener('data', function(chunk) {
-        if (typeof (chunk) === 'string') {
-            buffer += chunk;
-        } else {
-            buffer = Buffer.concat([buffer, chunk]);
-        }
+    self._tcpCloseListener = self._tcpClose.bind(self);
+    self.conn.addListener('close', self._tcpCloseListener);
 
-        var lines = self.convertEncoding(buffer).toString().split(lineDelimiter);
+    self._tcpErrorListener = self._tcpError.bind(self);
+    self.conn.addListener('error', self._tcpErrorListener);
+};
 
-        if (lines.pop()) {
-            // if buffer is not ended with \r\n, there's more chunks.
-            return;
-        } else {
-            // else, initialize the buffer.
-            buffer = new Buffer('');
-        }
+Client.prototype._tcpData = function(chunk) {
+    var self = this;
+    if (self._canary.field === 0.55) {
+        console.log("Canary ", self._canary);
+    }
+    if (typeof (chunk) === 'string') {
+        self._buffer += chunk;
+    } else {
+        self._buffer = Buffer.concat([self._buffer, chunk]);
+    }
 
-        lines.forEach(function iterator(line) {
-            if (line.length) {
-                var message = parseMessage(line, self.opt.stripColors);
+    var lines = self.convertEncoding(self._buffer).toString().split(lineDelimiter);
 
-                try {
-                    self.emit('raw', message);
-                } catch (err) {
-                    if (!self.conn.requestedDisconnect) {
-                        throw err;
-                    }
+    if (lines.pop()) {
+        // if buffer is not ended with \r\n, there's more chunks.
+        return;
+    } else {
+        // else, initialize the buffer.
+        self._buffer = new Buffer('');
+    }
+
+    lines.forEach(function iterator(line) {
+        if (line.length) {
+            var message = parseMessage(line, self.opt.stripColors);
+
+            try {
+                self.emit('raw', message);
+            } catch (err) {
+                if (!self.conn.requestedDisconnect) {
+                    throw err;
                 }
             }
-        });
-    });
-    self.conn.addListener('end', function() {
-        if (self.opt.debug)
-            util.log('Connection got "end" event');
-    });
-    self.conn.addListener('close', function() {
-        if (self.opt.debug)
-            util.log('Connection got "close" event');
-        if (self.conn.requestedDisconnect)
-            return;
-        if (self.opt.debug)
-            util.log('Disconnected: reconnecting');
-        if (self.opt.retryCount !== null && retryCount >= self.opt.retryCount) {
-            if (self.opt.debug) {
-                util.log('Maximum retry count (' + self.opt.retryCount + ') reached. Aborting');
-            }
-            self.emit('abort', self.opt.retryCount);
-            return;
-        }
-
-        if (self.opt.debug) {
-            util.log('Waiting ' + self.opt.retryDelay + 'ms before retrying');
-        }
-        setTimeout(function() {
-            self.connect(retryCount + 1);
-        }, self.opt.retryDelay);
-    });
-    self.conn.addListener('error', function(exception) {
-        self.emit('netError', exception);
-        if (self.opt.debug) {
-            util.log('Network error: ' + exception);
         }
     });
 };
+
+Client.prototype._tcpError = function(exception) {
+    this.emit('netError', exception);
+    if (this.opt.debug) {
+        util.log('Network error: ' + exception);
+    }
+};
+
+Client.prototype._tcpClose = function() {
+    var self = this;
+    if (self.opt.debug)
+        util.log('Connection got "close" event');
+    if (self.conn.requestedDisconnect)
+        return;
+    if (self.opt.debug)
+        util.log('Disconnected: reconnecting');
+    if (self.opt.retryCount !== null && self.retryCount >= self.opt.retryCount) {
+        if (self.opt.debug) {
+            util.log('Maximum retry count (' + self.opt.retryCount + ') reached. Aborting');
+        }
+        self.emit('abort', self.opt.retryCount);
+        return;
+    }
+
+    if (self.opt.debug) {
+        util.log('Waiting ' + self.opt.retryDelay + 'ms before retrying');
+    }
+    setTimeout(function() {
+        self.connect(self.retryCount + 1);
+    }, self.opt.retryDelay);
+};
+
 Client.prototype.disconnect = function(message, callback) {
-    if (typeof (message) === 'function') {
+    if (typeof (message) === 'fuRnction') {
         callback = message;
         message = undefined;
     }
@@ -977,6 +994,14 @@ Client.prototype.disconnect = function(message, callback) {
         self.conn.once('end', callback);
     }
     self.conn.end();
+
+    // cleanup all TCP connection listeners
+    this.removeListener("data", this._tcpDataListener);
+    this.removeListener("error", this._tcpErrorListener);
+    this.removeListener("close", this._tcpCloseListener);
+    this._tcpDataListener = null;
+    this._tcpErrorListener = null;
+    this._tcpCloseListener = null;
 };
 
 Client.prototype.send = function(command) {


### PR DESCRIPTION
Verified using heap snapshots, this now means that `irc.Client` instances WILL be GCed provided there are no references to it in `matrix-appservice-irc`.