### PR TITLE
Implement auto-connect upon socket timeout.

### DIFF
--- a/lib/irc.js
+++ b/lib/irc.js
@@ -887,7 +887,7 @@ Client.prototype.connect = function(retryCount, callback) {
         self.conn = net.createConnection(connectionOpts, self._connectionHandler.bind(self));
     }
     self.conn.requestedDisconnect = false;
-    self.conn.setTimeout(0);
+    self.conn.setTimeout(1000 * 180);
 
     if (!self.opt.encoding) {
         self.conn.setEncoding('utf8');
@@ -933,24 +933,12 @@ Client.prototype.connect = function(retryCount, callback) {
     self.conn.addListener('close', function() {
         if (self.opt.debug)
             util.log('Connection got "close" event');
-        if (self.conn.requestedDisconnect)
-            return;
+        self._reconnect(retryCount);
+    });
+    self.conn.addListener('timeout', function() {
         if (self.opt.debug)
-            util.log('Disconnected: reconnecting');
-        if (self.opt.retryCount !== null && retryCount >= self.opt.retryCount) {
-            if (self.opt.debug) {
-                util.log('Maximum retry count (' + self.opt.retryCount + ') reached. Aborting');
-            }
-            self.emit('abort', self.opt.retryCount);
-            return;
-        }
-
-        if (self.opt.debug) {
-            util.log('Waiting ' + self.opt.retryDelay + 'ms before retrying');
-        }
-        setTimeout(function() {
-            self.connect(retryCount + 1);
-        }, self.opt.retryDelay);
+            util.log('Connection got "timeout" event');
+        self._reconnect(retryCount);
     });
     self.conn.addListener('error', function(exception) {
         self.emit('netError', exception);
@@ -958,6 +946,27 @@ Client.prototype.connect = function(retryCount, callback) {
             util.log('Network error: ' + exception);
         }
     });
+};
+Client.prototype._reconnect = function reconnect(retryCount) {
+    var self = this;
+    if (self.conn.requestedDisconnect)
+        return;
+    if (self.opt.debug)
+        util.log('Disconnected: reconnecting');
+    if (self.opt.retryCount !== null && retryCount >= self.opt.retryCount) {
+        if (self.opt.debug) {
+            util.log('Maximum retry count (' + self.opt.retryCount + ') reached. Aborting');
+        }
+        self.emit('abort', self.opt.retryCount);
+        return;
+    }
+
+    if (self.opt.debug) {
+        util.log('Waiting ' + self.opt.retryDelay + 'ms before retrying');
+    }
+    setTimeout(function() {
+        self.connect(retryCount + 1);
+    }, self.opt.retryDelay);
 };
 Client.prototype.disconnect = function(message, callback) {
     if (typeof (message) === 'function') {


### PR DESCRIPTION
Prior, if the connection timed out during a reconnect, the open socket would just sit idly forever.

Now, after 180 seconds (I don't know the "best" timeout interval, but the the Quassel IRC client uses a ping timeout of 180 seconds) of socket inactivity, a reconnect is attempted.

I have tested the code with my own bots and it works.

cf. [hubot-irc/issues#93](https://github.com/nandub/hubot-irc/issues/93)