### PR TITLE
parseMessage: allow . (dot), : (comma) and / (slash) in the nickname

### DIFF
--- a/lib/parse_message.js
+++ b/lib/parse_message.js
@@ -23,7 +23,15 @@ module.exports = function parseMessage(line, stripColors) {
     if (match) {
         message.prefix = match[1];
         line = line.replace(/^:[^ ]+ +/, '');
-        match = message.prefix.match(/^([_a-zA-Z0-9\[\]\\`^{}|-]*)(!([^@]+)@(.*))?$/);
+
+        // Allow . (dot), : (colon) and / (slash) in the nickname for compatibility
+        // with certain substandard IRC implementations (like the PSYC's built-in IRC gate).
+        // However, only allow those characters when we are sure that we are not taking
+        // a server hostname for a nick (otherwise any server hostname would get misparsed
+        // as a nick without !user@host).
+
+        match = message.prefix.match(/^([_a-zA-Z0-9\[\]\\`^{}|-]*)(!([^@]+)@(.*))?$/) ||
+                message.prefix.match(/^([_a-zA-Z0-9\[\]\\`^{}|:./-]*)(!([^@]+)@(.*))$/);
         if (match) {
             message.nick = match[1];
             message.user = match[3];


### PR DESCRIPTION
Allow `.` (dot), `:` (colon) and `/` (slash) in the nickname for compatibility with certain substandard IRC implementations (like the PSYC's built-in IRC gate). However, only allow those characters when we are sure that we are not taking a server hostname for a nick (otherwise any server hostname would get misparsed as a nick without `!user@host`).