### PR TITLE
Make whois case insensitive

### DIFF
--- a/lib/irc.js
+++ b/lib/irc.js
@@ -449,34 +449,34 @@ function Client(server, nick, opt) {
                 }
                 break;
             case 'rpl_away':
-                self._addWhoisData(message.args[1], 'away', message.args[2], true);
+                self._addWhoisData(message.args[1].toLowerCase(), 'away', message.args[2], true);
                 break;
             case 'rpl_whoisuser':
-                self._addWhoisData(message.args[1], 'user', message.args[2]);
-                self._addWhoisData(message.args[1], 'host', message.args[3]);
-                self._addWhoisData(message.args[1], 'realname', message.args[5]);
+                self._addWhoisData(message.args[1].toLowerCase(), 'user', message.args[2]);
+                self._addWhoisData(message.args[1].toLowerCase(), 'host', message.args[3]);
+                self._addWhoisData(message.args[1].toLowerCase(), 'realname', message.args[5]);
                 break;
             case 'rpl_whoisidle':
-                self._addWhoisData(message.args[1], 'idle', message.args[2]);
+                self._addWhoisData(message.args[1].toLowerCase(), 'idle', message.args[2]);
                 break;
             case 'rpl_whoischannels':
                // TODO - clean this up?
                 if (message.args.length >= 3)
-                    self._addWhoisData(message.args[1], 'channels', message.args[2].trim().split(/\s+/));
+                    self._addWhoisData(message.args[1].toLowerCase(), 'channels', message.args[2].trim().split(/\s+/));
                 break;
             case 'rpl_whoisserver':
-                self._addWhoisData(message.args[1], 'server', message.args[2]);
-                self._addWhoisData(message.args[1], 'serverinfo', message.args[3]);
+                self._addWhoisData(message.args[1].toLowerCase(), 'server', message.args[2]);
+                self._addWhoisData(message.args[1].toLowerCase(), 'serverinfo', message.args[3]);
                 break;
             case 'rpl_whoisoperator':
-                self._addWhoisData(message.args[1], 'operator', message.args[2]);
+                self._addWhoisData(message.args[1].toLowerCase(), 'operator', message.args[2]);
                 break;
             case '330': // rpl_whoisaccount?
-                self._addWhoisData(message.args[1], 'account', message.args[2]);
-                self._addWhoisData(message.args[1], 'accountinfo', message.args[3]);
+                self._addWhoisData(message.args[1].toLowerCase(), 'account', message.args[2]);
+                self._addWhoisData(message.args[1].toLowerCase(), 'accountinfo', message.args[3]);
                 break;
             case 'rpl_endofwhois':
-                self.emit('whois', self._clearWhoisData(message.args[1]));
+                self.emit('whois', self._clearWhoisData(message.args[1].toLowerCase()));
                 break;
             case 'rpl_liststart':
                 self.channellist = [];
@@ -1186,7 +1186,7 @@ Client.prototype.getSplitMessages = function(target, text) {
 Client.prototype.whois = function(nick, callback) {
     if (typeof callback === 'function') {
         var callbackWrapper = function(info) {
-            if (info.nick.toLowerCase() == nick.toLowerCase()) {
+            if (info.nick.toLowerCase() === nick.toLowerCase()) {
                 this.removeListener('whois', callbackWrapper);
                 return callback.apply(this, arguments);
             }


### PR DESCRIPTION
Downcase the nick argument to all functions that deal with the internal whois
object so that the nick lookup is effectively case-insensitive.

After this is merged into master, the `package.json` dependencies for matrix-org/matrix-appservice-irc will need to be updated to point to the merge commit on this repository's master branch.

Fixes matrix-org/matrix-appservice-irc#496