### PR TITLE
Fix sending long messages

### DIFF
--- a/lib/irc.js
+++ b/lib/irc.js
@@ -1110,37 +1110,86 @@ Client.prototype.isUserPrefixMorePowerfulThan = function(prefix, testPrefix) {
     return this.supported.usermodepriority.indexOf(mode) < this.supported.usermodepriority.indexOf(testMode);
 };
 
-Client.prototype._splitLongLines = function(words, maxLength, destination) {
-    if (words.length == 0) {
-        return destination;
+Client.prototype._splitLongLines = function(text, maxLengthInBytes) {
+    // If maxLength hasn't been initialized yet, prefer an arbitrarily low
+    // line length over crashing.
+    maxLengthInBytes = maxLengthInBytes || 450;
+
+    if (maxLengthInBytes < 4) {
+        // That tight restriction makes no sense in IRC.
+        // Return immediately to prevent potential infinite loop.
+        return [text];
     }
-    if (words.length <= maxLength) {
-        destination.push(words);
-        return destination;
-    }
-    var c = words[maxLength];
-    var cutPos;
-    var wsLength = 1;
-    if (c.match(/\s/)) {
-        cutPos = maxLength;
-    } else {
-        var offset = 1;
-        while ((maxLength - offset) > 0) {
-            var c = words[maxLength - offset];
-            if (c.match(/\s/)) {
-                cutPos = maxLength - offset;
-                break;
+
+    var result = [];
+
+    var cutPosStart = 0, bytesStart = 0;
+    var cutPosWord  = 0, bytesWord  = 0;
+    var cutPosCurr  = 0, bytesCurr  = 0;
+    var wasSpace = true;
+
+    while (cutPosCurr < text.length) {
+        var utf8len, utf16len, isWhitespace;
+        if ((text.charCodeAt(cutPosCurr) & 0xF800) != 0xD800) {
+            utf8len = text.charCodeAt(cutPosCurr) <= 0x7f  ? 1
+                    : text.charCodeAt(cutPosCurr) <= 0x7ff ? 2
+                    : 3;
+            utf16len = 1;
+            isWhitespace = text[cutPosCurr].match(/\s/);
+        } else {
+            // Surrogate pair.
+            utf8len = 4;
+            utf16len = 2;
+            isWhitespace = false;
+        }
+
+        if (!wasSpace && isWhitespace) {
+            cutPosWord = cutPosCurr;
+            bytesWord  = bytesCurr;
+        }
+
+        if (bytesCurr + utf8len - bytesStart > maxLengthInBytes) {
+            if (cutPosWord != cutPosStart) {
+                cutPosCurr = cutPosWord;
+                bytesCurr  = bytesWord;
             }
-            offset++;
-        }
-        if (maxLength - offset <= 0) {
-            cutPos = maxLength;
-            wsLength = 0;
+
+            result.push(text.substring(cutPosStart, cutPosCurr));
+
+            // Skip leading spaces.
+            while (cutPosCurr < text.length && text[cutPosCurr].match(/\s/)) {
+                // According to [1], `/\s/` does not match code points beyond
+                // 0xffff. Consequently, we can assume that any whitespace
+                // character consists of single UTF-16 code unit, not a
+                // surrogate pair.
+                // [1]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp
+                cutPosCurr += 1;
+                bytesCurr += text.charCodeAt(cutPosCurr) <= 0x7f  ? 1
+                           : text.charCodeAt(cutPosCurr) <= 0x7ff ? 2
+                           : 3;
+            }
+
+            cutPosWord = cutPosStart = cutPosCurr;
+            bytesWord  = bytesStart = bytesCurr;
+            wasSpace = true;
+        } else {
+            cutPosCurr += utf16len;
+            bytesCurr  += utf8len;
+            wasSpace = isWhitespace;
         }
     }
-    var part = words.substring(0, cutPos);
-    destination.push(part);
-    return this._splitLongLines(words.substring(cutPos + wsLength, words.length), maxLength, destination);
+    if (cutPosStart != cutPosCurr) {
+        var startPos = cutPosStart;
+        if (result.length !== 0) {
+            while (startPos < text.length && text[startPos].match(/\s/)) {
+                startPos++;
+            }
+        }
+        if (startPos != text.length || result.length === 0) {
+            result.push(text.substring(startPos));
+        }
+    }
+    return result;
 };
 
 Client.prototype.say = function(target, text) {
@@ -1158,7 +1207,7 @@ Client.prototype._splitMessage = function(target, text) {
         return text.toString().split(/\r?\n/).filter(function(line) {
             return line.length > 0;
         }).map(function(line) {
-            return self._splitLongLines(line, maxLength, []);
+            return self._splitLongLines(line, maxLength);
         }).reduce(function(a, b) {
             return a.concat(b);
         }, []);

--- a/lib/irc.js
+++ b/lib/irc.js
@@ -1344,9 +1344,9 @@ Client.prototype.convertEncoding = function(str) {
 };
 // blatantly stolen from irssi's splitlong.pl. Thanks, Bjoern Krombholz!
 Client.prototype._updateMaxLineLength = function() {
-    // 497 = 510 - (":" + "!" + " PRIVMSG " + " :").length;
+    // 496 = 510 - (":" + "!" + " PRIVMSG " + " :-").length;
     // target is determined in _speak() and subtracted there
-    this.maxLineLength = 497 - this.nick.length - this.hostMask.length;
+    this.maxLineLength = 496 - this.nick.length - this.hostMask.length;
 };
 
 // Checks the arg at the given index for a channel. If one exists, casemap it

--- a/test/data/fixtures.json
+++ b/test/data/fixtures.json
@@ -176,6 +176,56 @@
             "input": "abc abcdef abc abcd abc",
             "maxLength": 5,
             "result": ["abc", "abcde", "f abc", "abcd", "abc"]
+        },
+        {
+            "input": "æøå",
+            "maxLength": 4,
+            "result": ["æø", "å"]
+        },
+        {
+            "input": "æøå",
+            "maxLength": 5,
+            "result": ["æø", "å"]
+        },
+        {
+            "input": "\u000308\u0002\u0002\u0002bold and yellow\u0002\u0003",
+            "maxLength": 12,
+            "result": ["\u000308\u0002\u0002\u0002bold", "and yellow\u0002\u0003"]
+        },
+        {
+            "input": "abc ",
+            "maxLength": 5,
+            "result": ["abc "]
+        },
+        {
+            "input": " abc",
+            "maxLength": 5,
+            "result": [" abc"]
+        },
+        {
+            "input": " abc ",
+            "maxLength": 5,
+            "result": [" abc "]
+        },
+        {
+            "input": " abc abc abc abc ",
+            "maxLength": 5,
+            "result": [" abc", "abc", "abc", "abc "]
+        },
+        {
+            "input": "αβγδε αβγδaε αβγδεa",
+            "maxLength": 6,
+            "result": ["αβγ", "δε", "αβγ", "δaε", "αβγ", "δεa"]
+        },
+        {
+            "input": "αβγδε",
+            "maxLength": 5,
+            "result": ["αβ", "γδ", "ε"]
+        },
+        {
+            "input": "abcdefg 😸😹😺😻 😸😹a😺😻",
+            "maxLength": 9,
+            "result": ["abcdefg", "😸😹", "😺😻", "😸😹a", "😺😻"]
         }
     ]
 }


### PR DESCRIPTION
## Unicode-aware text splitting

### Problem

IRC servers have message size limit in bytes. Current implementation of `_splitLongLines` function counts UTF-16 code units, not bytes. This leads to incorrect text splitting.

### Related issues

* https://github.com/matrix-org/matrix-appservice-irc/issues/238
* https://github.com/martynsmith/node-irc/issues/255
* https://github.com/martynsmith/node-irc/pull/464
* https://github.com/martynsmith/node-irc/issues/507

### Solution

I have implemented text splitting algorithm that is aware of UTF-8 code points byte size. It is also aware of UTF-16 surrogate pairs (since internal javascript string representation is UTF-16) in order to correctly handle characters like emojis.

### Futher work

Try not to split symbols that consist of multiple unicode code points. Examples are:

* `č` (`U+0063 LATIN SMALL LETTER C` + `U+030C COMBINING CARON`).
* `🧜🏽` (`U+1F9DC MERPERSON` + `U+1F3FD EMOJI MODIFIER FITZPATRICK TYPE-4`).
* `👁️‍🗨️` (`U+1F441 EYE` + `U+200D ZERO WIDTH JOINER` + `U+1F5E8 LEFT SPEECH BUBBLE`).

I have no interest in implementing this, but it is still should be taken into account.


## Reduce maxLineLength by one to accomodate `identify-msg` extension

### Problem

The [identify-msg] Client Capability Extension is not taken into account. It takes one byte of the message, leaving less space for the message text itself. This may lead to truncating the last byte of the message being send. Freenode implements this extension: [src/send.c].

### Related issue

* https://github.com/matrix-org/matrix-appservice-irc/issues/135

### Solution

I have reduced calculated `maxLineLength` limit by one byte.


[src/send.c]: https://github.com/freenode/ircd-seven/blob/02023be9f8cdd13937814eb83ed4445b7be5081a/src/send.c#L1244-L1250
[identify-msg]: https://github.com/grawity/irc-docs/blob/master/client/cap-identify-msg.md