### PR TITLE
Use ChannelCache to cache channels between clients

### DIFF
--- a/lib/channel_cache.js
+++ b/lib/channel_cache.js
@@ -104,8 +104,18 @@ class ChannelCache {
         let res = channelSet.delete(key);
         if (res && channelSet.size === 0) {
             this.clientChannels.delete(clientId);
+            this.clearUnusedChannel()
         }
         return res;
+    }
+
+    clearUnusedChannel(channelName) {
+        for (const clientChannels of this.clientChannels.values()) {
+            if (clientChannels.includes(channelName)){
+                return;
+            }
+        }
+        this.channels.delete(channelName);
     }
     
     createChannel(channelName) {

--- a/lib/channel_cache.js
+++ b/lib/channel_cache.js
@@ -39,7 +39,7 @@ class Channel {
     }
 
     changeUserNick(oldNick, newNick) {
-        this._users.set(newNick);
+        this._users.add(newNick);
         // If we didn't delete the old nick, then we don't need to change the mode.
         if (!this._users.delete(oldNick)) {
             return;
@@ -53,7 +53,7 @@ class Channel {
     }
 
     addUser(nick) {
-        if (this._users.set(nick)) {
+        if (this._users.add(nick)) {
             this.userModePrefix[nick] = "";
             return true;
         }
@@ -88,7 +88,7 @@ class ChannelCache {
             this.clientChannels.set(clientId, channelSet);
         }
         const key = channelName.toLowerCase();
-        return channelSet.set(key);
+        return channelSet.add(key);
     }
     /**
      * Mark the client as left from the channel.

--- a/lib/channel_cache.js
+++ b/lib/channel_cache.js
@@ -53,11 +53,11 @@ class Channel {
     }
 
     addUser(nick) {
-        if (this._users.add(nick)) {
-            this.userModePrefix[nick] = "";
-            return true;
+        if (this._users.has(nick)) {
+            return;
         }
-        return false;
+        this._users.add(nick)
+        this.userModePrefix[nick] = "";
     }
 
     removeUser(nick) {

--- a/lib/channel_cache.js
+++ b/lib/channel_cache.js
@@ -1,6 +1,6 @@
 class Channel {
     constructor(channelName) {
-        this._users = Set();
+        this._users = new Set();
         this.userModePrefix = [];
         this.key = channelName.toLowerCase();
         this.serverName = channelName;

--- a/lib/channel_cache.js
+++ b/lib/channel_cache.js
@@ -137,7 +137,20 @@ class ChannelCache {
         if (!this.clientChannels.has(clientId)) {
             return [];
         }
-        return this.clientChannels.get(clientId).map((chan) => this.channels.get(chan));
+        const chanObj = { };
+        return this.clientChannels.get(clientId).forEach((chan) => chanObj);
+    }
+
+    getChannelsObject(clientId) {
+        if (!this.clientChannels.has(clientId)) {
+            return {};
+        }
+        const chanObj = { };
+        this.clientChannels.get(clientId).forEach(
+            (chan) => {
+                chanObj[chan.key] = chan
+        });
+        return chanObj;
     }
 
     getChannelForClient(clientId, channelName) {

--- a/lib/channel_cache.js
+++ b/lib/channel_cache.js
@@ -137,8 +137,7 @@ class ChannelCache {
         if (!this.clientChannels.has(clientId)) {
             return [];
         }
-        const chanObj = { };
-        return this.clientChannels.get(clientId).forEach((chan) => chanObj);
+        return this.clientChannels.get(clientId).forEach((chanName) => this.channels.get(chanName));
     }
 
     getChannelsObject(clientId) {
@@ -147,8 +146,9 @@ class ChannelCache {
         }
         const chanObj = { };
         this.clientChannels.get(clientId).forEach(
-            (chan) => {
-                chanObj[chan.key] = chan
+            (chanName) => {
+                const channel = this.channels.get(chanName);
+                chanObj[channel.key] = channel;
         });
         return chanObj;
     }
@@ -160,6 +160,7 @@ class ChannelCache {
             return this.channels.get(key);
         }
     }
+
 }
 
 module.exports = ChannelCache;

--- a/lib/channel_cache.js
+++ b/lib/channel_cache.js
@@ -73,74 +73,88 @@ class Channel {
 class ChannelCache {
     constructor() {
         this.channels = new Map(); /* channelname -> Channel */
-        this.clientChannels = new Map(); /* client_id:Set(channelname) */
+        this.clientChannels = new Map(); /* client_id:Set(Channel) */
     }
 
     /**
      * Mark the client as joined to the channel.
      * @param {number} clientId The ID of the connection.
-     * @param {string} channelName The IRC channel name.
+     * @param {string} channel The IRC channel.
      */
-    markClientJoined(clientId, channelName) {
+    markClientJoined(clientId, channel) {
         let channelSet = this.clientChannels.get(clientId);
         if (channelSet === undefined) {
             channelSet = new Set();
             this.clientChannels.set(clientId, channelSet);
         }
-        const key = channelName.toLowerCase();
-        return channelSet.add(key);
+        if (channel !== undefined) {
+            return channelSet.add(chan);
+        }
+        return false;
     }
     /**
      * Mark the client as left from the channel.
      * @param {number} clientId The ID of the connection.
-     * @param {string} channelName The IRC channel name.
+     * @param {Channel} channel The IRC channel.
      */
-    markClientLeft(clientId, channelName) {
+    markClientLeft(clientId, channel) {
         let channelSet = this.clientChannels.get(clientId);
         if (channelSet === undefined) {
             return;
         }
-        const key = channelName.toLowerCase();
-        let res = channelSet.delete(key);
+        let res = channelSet.delete(channel);
         if (res && channelSet.size === 0) {
             this.clientChannels.delete(clientId);
-            this.clearUnusedChannel()
+            this.clearUnusedChannel();
         }
         return res;
     }
 
-    clearUnusedChannel(channelName) {
+    /**
+     * Clear an unused channel from the cache
+     * IF no clients are joined to it.
+     * @param {Channel} channel The IRC channel.
+     */
+    clearUnusedChannel(channel) {
         for (const clientChannels of this.clientChannels.values()) {
-            if (clientChannels.includes(channelName)){
+            if (clientChannels.includes(channel)){
                 return;
             }
         }
-        this.channels.delete(channelName);
+        this.channels.delete(channel);
     }
     
+    /**
+     * Create a new Channel if it does not exist.
+     * channelName is automatically lowecased.
+     * @param {string} channelName 
+     * @returns {Channel} Returns the created channel, or the prexisting channel.
+     */
     createChannel(channelName) {
         const key = channelName.toLowerCase();
         if (this.channels.has(key)) {
-            return false;
+            return this.channels.get(key);
         }
-        this.channels.set(channelName,new Channel(channelName));
+        const chan = new Channel(channelName);
+        this.channels.set(channelName, chan);
+        return chan;
     }
 
-    getChannelList(clientId) {
+    getClientChannelNames(clientId) {
         if (!this.clientChannels.has(clientId)) {
             return [];
         }
-        return [...this.clientChannels.get(clientId)];
+        return [...this.clientChannels.get(clientId)].map((channel) => channel.key);
     }
 
-    getChannels(clientId) {
+    getClientChannels(clientId) {
         if (!this.clientChannels.has(clientId)) {
             return [];
         }
-        return this.clientChannels.get(clientId).forEach((chanName) => this.channels.get(chanName));
+        return this.clientChannels.get(clientId);
     }
 
-    getChannelsObject(clientId) {
+    getClientChannelsObject(clientId) {
         if (!this.clientChannels.has(clientId)) {
             return {};
         }
@@ -155,10 +169,10 @@ class ChannelCache {
 
     getChannelForClient(clientId, channelName) {
         const key = channelName.toLowerCase();
-        if (this.clientChannels.has (clientId) && 
-            this.clientChannels.get(clientId).has(key)) {
-            return this.channels.get(key);
+        if (!this.clientChannels.has (clientId)){
+            return;
         }
+        return [...this.clientChannels.get(clientId)].find((chan) => chan.key === key);
     }
 
 }

--- a/lib/channel_cache.js
+++ b/lib/channel_cache.js
@@ -160,8 +160,7 @@ class ChannelCache {
         }
         const chanObj = { };
         this.clientChannels.get(clientId).forEach(
-            (chanName) => {
-                const channel = this.channels.get(chanName);
+            (channel) => {
                 chanObj[channel.key] = channel;
         });
         return chanObj;

--- a/lib/channel_cache.js
+++ b/lib/channel_cache.js
@@ -113,12 +113,7 @@ class ChannelCache {
         if (this.channels.has(key)) {
             return false;
         }
-        this.channels.set({
-            users: new Set(),
-            serverName: channelName,
-            key,
-            mode: ""
-        });
+        this.channels.set(channelName,new Channel(channelName));
     }
 
     addUserToChannel(channelName, user) {

--- a/lib/channel_cache.js
+++ b/lib/channel_cache.js
@@ -138,16 +138,23 @@ class ChannelCache {
     }
 
     getChannelList(clientId) {
+        if (!this.clientChannels.has(clientId)) {
+            return [];
+        }
         return [...this.clientChannels.get(clientId)];
     }
 
     getChannels(clientId) {
+        if (!this.clientChannels.has(clientId)) {
+            return [];
+        }
         return this.clientChannels.get(clientId).map((chan) => this.channels.get(chan));
     }
 
     getChannelForClient(clientId, channelName) {
         const key = channelName.toLowerCase();
-        if (this.clientChannels.get(clientId).has(key)) {
+        if (this.clientChannels.has (clientId) && 
+            this.clientChannels.get(clientId).has(key)) {
             return this.channels.get(key);
         }
     }

--- a/lib/channel_cache.js
+++ b/lib/channel_cache.js
@@ -1,0 +1,156 @@
+class Channel {
+    constructor(channelName) {
+        this._users = Set();
+        this.userModePrefix = [];
+        this.key = channelName.toLowerCase();
+        this.serverName = channelName;
+        this.created = null;
+        this.mode = "";
+        this.topic = null;
+        this.topicBy = null;
+    }
+
+    get users() {
+        return this.userModePrefix;
+    }
+
+    setUserPrefix(nick, mode) {
+        this.userModePrefix[nick] = mode;
+    }
+
+    clearUserPrefix(nick, mode) {
+        this.userModePrefix[nick] = "";
+    }
+
+    addUserPrefix(nick, mode) {
+        if (!this._users.has(nick)) {
+            return;
+        }
+        if (!this.userModePrefix[nick].includes(mode)) {
+            this.userModePrefix += mode;
+        }
+    }
+
+    removeUserPrefix(nick, mode) {
+        if (!this._users.has(nick)) {
+            return;
+        }
+        this.userModePrefix[nick] = this.userModePrefix[nick].replace(mode, '');
+    }
+
+    changeUserNick(oldNick, newNick) {
+        this._users.set(newNick);
+        // If we didn't delete the old nick, then we don't need to change the mode.
+        if (!this._users.delete(oldNick)) {
+            return;
+        }
+        this.userModePrefix[newNick] = this.userModePrefix[oldNick];
+        delete this.userModePrefix[oldNick];
+    }
+
+    userInChannel(nick) {
+        return this._users.has(nick);
+    }
+
+    addUser(nick) {
+        if (this._users.set(nick)) {
+            this.userModePrefix[nick] = "";
+            return true;
+        }
+        return false;
+    }
+
+    removeUser(nick) {
+        if (this._users.delete(nick)) {
+            delete this.userModePrefix[nick];
+            return true;
+        }
+        return false;
+    }
+}
+
+/* A class to be shared between client instances to reduce memory footprint */
+class ChannelCache {
+    constructor() {
+        this.channels = new Map(); /* channelname -> Channel */
+        this.clientChannels = new Map(); /* client_id:Set(channelname) */
+    }
+
+    /**
+     * Mark the client as joined to the channel.
+     * @param {number} clientId The ID of the connection.
+     * @param {string} channelName The IRC channel name.
+     */
+    markClientJoined(clientId, channelName) {
+        let channelSet = this.clientChannels.get(clientId);
+        if (channelSet === undefined) {
+            channelSet = new Set();
+            this.clientChannels.set(clientId, channelSet);
+        }
+        const key = channelName.toLowerCase();
+        return channelSet.set(key);
+    }
+    /**
+     * Mark the client as left from the channel.
+     * @param {number} clientId The ID of the connection.
+     * @param {string} channelName The IRC channel name.
+     */
+    markClientLeft(clientId, channelName) {
+        let channelSet = this.clientChannels.get(clientId);
+        if (channelSet === undefined) {
+            return;
+        }
+        const key = channelName.toLowerCase();
+        let res = channelSet.delete(key);
+        if (res && channelSet.size === 0) {
+            this.clientChannels.delete(clientId);
+        }
+        return res;
+    }
+    
+    createChannel(channelName) {
+        const key = channelName.toLowerCase();
+        if (this.channels.has(key)) {
+            return false;
+        }
+        this.channels.set({
+            users: new Set(),
+            serverName: channelName,
+            key,
+            mode: ""
+        });
+    }
+
+    addUserToChannel(channelName, user) {
+        const key = channelName.toLowerCase();
+        let chan = this.channels.get(key)
+        if (chan === undefined) {
+            return; //Dropping this because we don't know about the channel yet.
+        }
+    }
+
+    removeUserFromChannel(channel, user) {
+
+    }
+
+    setChannelMode() {
+
+    }
+
+    getChannelList(clientId) {
+        return [...this.clientChannels.get(clientId)];
+    }
+
+    getChannels(clientId) {
+        return this.clientChannels.get(clientId).map((chan) => this.channels.get(chan));
+    }
+
+    getChannelForClient(clientId, channelName) {
+        const key = channelName.toLowerCase();
+        if (this.clientChannels.get(clientId).has(key)) {
+            return this.channels.get(key);
+        }
+    }
+}
+
+module.exports = ChannelCache;

--- a/lib/channel_cache.js
+++ b/lib/channel_cache.js
@@ -105,7 +105,7 @@ class ChannelCache {
         let res = channelSet.delete(channel);
         if (res && channelSet.size === 0) {
             this.clientChannels.delete(clientId);
-            this.clearUnusedChannel();
+            this.clearUnusedChannel(channel);
         }
         return res;
     }
@@ -116,8 +116,8 @@ class ChannelCache {
      * @param {Channel} channel The IRC channel.
      */
     clearUnusedChannel(channel) {
-        for (const clientChannels of this.clientChannels.values()) {
-            if (clientChannels.includes(channel)){
+        for (const chanSet of this.clientChannels.values()) {
+            if (chanSet.has(channel)){
                 return;
             }
         }

--- a/lib/channel_cache.js
+++ b/lib/channel_cache.js
@@ -88,7 +88,7 @@ class ChannelCache {
             this.clientChannels.set(clientId, channelSet);
         }
         if (channel !== undefined) {
-            return channelSet.add(chan);
+            return channelSet.add(channel);
         }
         return false;
     }

--- a/lib/channel_cache.js
+++ b/lib/channel_cache.js
@@ -116,22 +116,6 @@ class ChannelCache {
         this.channels.set(channelName,new Channel(channelName));
     }
 
-    addUserToChannel(channelName, user) {
-        const key = channelName.toLowerCase();
-        let chan = this.channels.get(key)
-        if (chan === undefined) {
-            return; //Dropping this because we don't know about the channel yet.
-        }
-    }
-
-    removeUserFromChannel(channel, user) {
-
-    }
-
-    setChannelMode() {
-
-    }
-
     getChannelList(clientId) {
         if (!this.clientChannels.has(clientId)) {
             return [];

--- a/lib/irc.js
+++ b/lib/irc.js
@@ -26,7 +26,10 @@ const EventEmitter = require('events').EventEmitter;
 
 const colors = require('./colors');
 const parseMessage = require('./parse_message');
+const ChannelCache = require('./channel_cache');
+
 exports.colors = colors;
+exports.ChannelCache = ChannelCache;
 
 var lineDelimiter = new RegExp('\r\n|\r|\n')
 
@@ -77,7 +80,9 @@ function Client(server, nick, opt) {
           pass: '',
           ip: '',
           user: ''
-        }
+        },
+        clientId: -1,
+        channelCache: new ChannelCache(),
     };
 
     // Features supported by the server
@@ -126,8 +131,7 @@ function Client(server, nick, opt) {
     var prevClashNick = '';
 
     self.addListener('raw', function(message) {
-        var channels = [],
-            channel,
+            let channel,
             nick,
             from,
             text,
@@ -325,16 +329,14 @@ function Client(server, nick, opt) {
                         // channel user modes
                         var user = modeArgs.shift();
                         if (adding) {
-                            if (channel.users[user] != null && channel.users[user].indexOf(self.prefixForMode[mode]) === -1) {
-                                channel.users[user] += self.prefixForMode[mode];
-                            }
-
+                            //if (channel.users[user] != null && channel.users[user].indexOf(self.prefixForMode[mode]) === -1) {
+                            //    channel.users[user] += self.prefixForMode[mode];
+                            //}
+                            channel.addUserPrefix(user, self.prefixForMode[mode]);
                             self.emit('+mode', message.args[0], message.nick, mode, user, message);
                         }
                         else {
-                            if (channel.users[user]) {
-                                channel.users[user] = channel.users[user].replace(self.prefixForMode[mode], '');
-                            }
+                            channel.removeUserPrefix(user, self.prefixForMode[mode]);
                             self.emit('-mode', message.args[0], message.nick, mode, user, message);
                         }
                     }
@@ -370,14 +372,12 @@ function Client(server, nick, opt) {
                 if (self.opt.debug)
                     util.log('NICK: ' + message.nick + ' changes nick to ' + message.args[0]);
 
-                channels = [];
+                const channels = [];
 
                 // finding what channels a user is in
-                Object.keys(self.chans).forEach(function(channame) {
-                    var channel = self.chans[channame];
-                    if (message.nick in channel.users) {
-                        channel.users[message.args[0]] = channel.users[message.nick];
-                        delete channel.users[message.nick];
+                self.channelCache.getChannels(self.clientId).forEach((channel) => {
+                    if (channel.userInChannel(message.nick)) {
+                        channel.changeUserNick(message.nick, message.args[0]);
                         channels.push(channame);
                     }
                 });
@@ -421,12 +421,14 @@ function Client(server, nick, opt) {
                                 }
                             }
                             if (knownPrefixes.length > 0) {
-                                channel.users[match[2]] = knownPrefixes;
+                                channel.addUser(match[2]);
+                                channel.setUserMode(match[2], knownPrefixes);
                             }
                             else {
                                 // recombine just in case this server allows weird chars in the nick.
                                 // We know it isn't a mode char.
-                                channel.users[match[1] + match[2]] = '';
+                                channel.addUser(match[1] + match[2]);
+                                channel.setUserMode(match[1] + match[2], "");
                             }
                         }
                     });
@@ -538,8 +540,8 @@ function Client(server, nick, opt) {
                 }
                 else {
                     channel = self.chanData(message.args[0]);
-                    if (channel && channel.users) {
-                        channel.users[message.nick] = '';
+                    if (channel) {
+                        channel.addUser(message.nick);
                     }
                 }
                 self.emit('join', message.args[0], message.nick, message);
@@ -558,12 +560,13 @@ function Client(server, nick, opt) {
                 }
                 if (self.nick == message.nick) {
                     channel = self.chanData(message.args[0]);
-                    delete self.chans[channel.key];
+                    channel.removeUser(message.nick);
+                    this.opt.channelCache.markClientLeft(this.opt.clientId, message.args[0]);
                 }
                 else {
                     channel = self.chanData(message.args[0]);
-                    if (channel && channel.users) {
-                        delete channel.users[message.nick];
+                    if (channel) {
+                        channel.removeUser(message.nick);
                     }
                 }
                 break;
@@ -579,23 +582,23 @@ function Client(server, nick, opt) {
 
                 if (self.nick == message.args[1]) {
                     channel = self.chanData(message.args[0]);
-                    delete self.chans[channel.key];
+                    channel.removeUser(message.args[1]);
+                    this.opt.channelCache.markClientLeft(this.opt.clientId, message.args[1]);
                 }
                 else {
                     channel = self.chanData(message.args[0]);
-                    if (channel && channel.users) {
-                        delete channel.users[message.args[1]];
+                    if (channel) {
+                        channel.removeUser(message.args[1]);
                     }
                 }
                 break;
             case 'KILL':
                 nick = message.args[0];
                 channels = [];
-                Object.keys(self.chans).forEach(function(channame) {
-                    var channel = self.chans[channame];
-                    if (nick in channel.users) {
-                        channels.push(channame);
-                        delete channel.users[nick];
+                this.opt.channelCache.getChannels(this.opt.clientId).forEach(function(channel) {
+                    if (channel.userInChannel(nick)) {
+                        channels.push(channel.key);
+                        channel.removeUser(nick);
                     }
                 });
                 self.emit('kill', nick, message.args[1], channels, message);
@@ -641,11 +644,10 @@ function Client(server, nick, opt) {
                 channels = [];
 
                 // finding what channels a user is in?
-                Object.keys(self.chans).forEach(function(channame) {
-                    var channel = self.chans[channame];
-                    if (message.nick in channel.users) {
-                        delete channel.users[message.nick];
-                        channels.push(channame);
+                this.opt.channelCache.getChannels(this.opt.clientId).forEach(function(channel) {
+                    if (channel.userInChannel(nick)) {
+                        channels.push(channel.key);
+                        channel.removeUser(nick);
                     }
                 });
 
@@ -739,21 +741,23 @@ util.inherits(Client, EventEmitter);
 Client.prototype.conn = null;
 Client.prototype.prefixForMode = {}; // o => @
 Client.prototype.modeForPrefix = {}; // @ => o
-Client.prototype.chans = {};
+Object.defineProperty(Client.prototype, 'chans', {
+    get: () => {
+        return this.opt.channelCache.getChannelList(this.opt.clientId);
+    }
+});
 Client.prototype._whoisData = {};
 
 Client.prototype.chanData = function(name, create) {
     var key = name.toLowerCase();
     if (create) {
-        this.chans[key] = this.chans[key] || {
-            key: key,
-            serverName: name,
-            users: {},
-            mode: ''
-        };
+        this.opt.channelCache.createChannel(name);
+        this.opt.channelCache.markClientJoined(this.opt.clientId, name);
     }
-
-    return this.chans[key];
+    return this.opt.channelCache.getChannelForClient(
+        this.opt.clientId,
+        name
+    );
 };
 
 Client.prototype._connectionHandler = function() {
@@ -785,7 +789,6 @@ Client.prototype.connect = function(retryCount, callback) {
         this.once('registered', callback);
     }
     var self = this;
-    self.chans = {};
 
     // socket opts
     var connectionOpts = {

--- a/lib/irc.js
+++ b/lib/irc.js
@@ -374,7 +374,7 @@ function Client(server, nick, opt) {
                     util.log('NICK: ' + message.nick + ' changes nick to ' + message.args[0]);
 
                 // finding what channels a user is in
-                self.opts.channelCache.getClientChannels(self.clientId).forEach((channel) => {
+                self.opt.channelCache.getClientChannels(self.clientId).forEach((channel) => {
                     if (channel.userInChannel(message.nick)) {
                         channel.changeUserNick(message.nick, message.args[0]);
                         channels.push(channel.serverName);

--- a/lib/irc.js
+++ b/lib/irc.js
@@ -374,7 +374,7 @@ function Client(server, nick, opt) {
                     util.log('NICK: ' + message.nick + ' changes nick to ' + message.args[0]);
 
                 // finding what channels a user is in
-                self.channelCache.getClientChannels(self.clientId).forEach((channel) => {
+                self.opts.channelCache.getClientChannels(self.clientId).forEach((channel) => {
                     if (channel.userInChannel(message.nick)) {
                         channel.changeUserNick(message.nick, message.args[0]);
                         channels.push(channel.serverName);
@@ -562,7 +562,7 @@ function Client(server, nick, opt) {
                     channel.removeUser(message.nick);
                 }
                 if (self.nick == message.nick) {
-                    this.opt.channelCache.markClientLeft(this.opt.clientId, channel);
+                    self.opt.channelCache.markClientLeft(this.opt.clientId, channel);
                 }
                 break;
             case 'KICK':
@@ -578,7 +578,7 @@ function Client(server, nick, opt) {
                 if (self.nick == message.args[1]) {
                     channel = self.chanData(message.args[0]);
                     channel.removeUser(message.args[1]);
-                    this.opt.channelCache.markClientLeft(this.opt.clientId, message.args[1]);
+                    self.opt.channelCache.markClientLeft(this.opt.clientId, message.args[1]);
                 }
                 else {
                     channel = self.chanData(message.args[0]);
@@ -589,7 +589,7 @@ function Client(server, nick, opt) {
                 break;
             case 'KILL':
                 nick = message.args[0];
-                this.opt.channelCache.getChannels(this.opt.clientId).forEach(function(channel) {
+                self.opt.channelCache.getChannels(this.opt.clientId).forEach(function(channel) {
                     if (channel.userInChannel(nick)) {
                         channels.push(channel.key);
                         channel.removeUser(nick);
@@ -637,7 +637,7 @@ function Client(server, nick, opt) {
 
 
                 // finding what channels a user is in?
-                this.opt.channelCache.getChannels(this.opt.clientId).forEach(function(channel) {
+                self.opt.channelCache.getChannels(this.opt.clientId).forEach(function(channel) {
                     if (channel.userInChannel(nick)) {
                         channels.push(channel.key);
                         channel.removeUser(nick);

--- a/lib/irc.js
+++ b/lib/irc.js
@@ -589,7 +589,7 @@ function Client(server, nick, opt) {
                 break;
             case 'KILL':
                 nick = message.args[0];
-                self.opt.channelCache.getChannels(this.opt.clientId).forEach(function(channel) {
+                self.opt.channelCache.getClientChannels(this.opt.clientId).forEach(function(channel) {
                     if (channel.userInChannel(nick)) {
                         channels.push(channel.key);
                         channel.removeUser(nick);
@@ -637,7 +637,7 @@ function Client(server, nick, opt) {
 
 
                 // finding what channels a user is in?
-                self.opt.channelCache.getChannels(this.opt.clientId).forEach(function(channel) {
+                self.opt.channelCache.getClientChannels(this.opt.clientId).forEach(function(channel) {
                     if (channel.userInChannel(nick)) {
                         channels.push(channel.key);
                         channel.removeUser(nick);

--- a/lib/irc.js
+++ b/lib/irc.js
@@ -742,7 +742,7 @@ Client.prototype.conn = null;
 Client.prototype.prefixForMode = {}; // o => @
 Client.prototype.modeForPrefix = {}; // @ => o
 Object.defineProperty(Client.prototype, 'chans', {
-    get: () => {
+    get: function() {
         return this.opt.channelCache.getChannelList(this.opt.clientId);
     }
 });

--- a/lib/irc.js
+++ b/lib/irc.js
@@ -18,14 +18,14 @@
 */
 
 exports.Client = Client;
-var dns  = require('dns');
-var net  = require('net');
-var tls  = require('tls');
-var util = require('util');
-var EventEmitter = require('events').EventEmitter;
+const dns  = require('dns');
+const net  = require('net');
+const tls  = require('tls');
+const util = require('util');
+const EventEmitter = require('events').EventEmitter;
 
-var colors = require('./colors');
-var parseMessage = require('./parse_message');
+const colors = require('./colors');
+const parseMessage = require('./parse_message');
 exports.colors = colors;
 
 var lineDelimiter = new RegExp('\r\n|\r|\n')

--- a/lib/irc.js
+++ b/lib/irc.js
@@ -437,8 +437,8 @@ function Client(server, nick, opt) {
                 self._casemap(message, 1);
                 channel = self.chanData(message.args[1]);
                 if (channel) {
-                    self.emit('names', message.args[1], channel.users);
-                    self.emit('names' + message.args[1], channel.users);
+                    self.emit('names', message.args[1], Object.assign({}, channel.users));
+                    self.emit('names' + message.args[1], Object.assign({}, channel.users));
                     self.send('MODE', message.args[1]);
                 }
                 break;

--- a/lib/irc.js
+++ b/lib/irc.js
@@ -131,11 +131,11 @@ function Client(server, nick, opt) {
     var prevClashNick = '';
 
     self.addListener('raw', function(message) {
-            let channel,
-            nick,
-            from,
-            text,
-            to;
+        let channel,
+        nick,
+        from,
+        text,
+        to;
 
         switch (message.command) {
             case 'rpl_welcome':
@@ -558,7 +558,7 @@ function Client(server, nick, opt) {
                 if (message.args[0] != message.args[0].toLowerCase()) {
                     self.emit('part' + message.args[0].toLowerCase(), message.nick, message.args[1], message);
                 }
-                const channel = self.chanData(message.args[0]);
+                channel = self.chanData(message.args[0]);
                 if (channel) {
                     channel.removeUser(message.nick);
                 }

--- a/lib/irc.js
+++ b/lib/irc.js
@@ -743,7 +743,7 @@ Client.prototype.prefixForMode = {}; // o => @
 Client.prototype.modeForPrefix = {}; // @ => o
 Object.defineProperty(Client.prototype, 'chans', {
     get: function() {
-        return this.opt.channelCache.getChannelList(this.opt.clientId);
+        return this.opt.channelCache.getChannelsObject(this.opt.clientId);
     }
 });
 Client.prototype._whoisData = {};

--- a/lib/irc.js
+++ b/lib/irc.js
@@ -558,16 +558,12 @@ function Client(server, nick, opt) {
                 if (message.args[0] != message.args[0].toLowerCase()) {
                     self.emit('part' + message.args[0].toLowerCase(), message.nick, message.args[1], message);
                 }
-                if (self.nick == message.nick) {
-                    channel = self.chanData(message.args[0]);
+                const channel = self.chanData(message.args[0]);
+                if (channel) {
                     channel.removeUser(message.nick);
-                    this.opt.channelCache.markClientLeft(this.opt.clientId, message.args[0]);
                 }
-                else {
-                    channel = self.chanData(message.args[0]);
-                    if (channel) {
-                        channel.removeUser(message.nick);
-                    }
+                if (self.nick == message.nick) {
+                    this.opt.channelCache.markClientLeft(this.opt.clientId, channel);
                 }
                 break;
             case 'KICK':
@@ -743,16 +739,15 @@ Client.prototype.prefixForMode = {}; // o => @
 Client.prototype.modeForPrefix = {}; // @ => o
 Object.defineProperty(Client.prototype, 'chans', {
     get: function() {
-        return this.opt.channelCache.getChannelsObject(this.opt.clientId);
+        return this.opt.channelCache.getClientChannelsObject(this.opt.clientId);
     }
 });
 Client.prototype._whoisData = {};
 
 Client.prototype.chanData = function(name, create) {
-    var key = name.toLowerCase();
     if (create) {
-        this.opt.channelCache.createChannel(name);
-        this.opt.channelCache.markClientJoined(this.opt.clientId, name);
+        const chan = this.opt.channelCache.createChannel(name);
+        this.opt.channelCache.markClientJoined(this.opt.clientId, chan);
     }
     return this.opt.channelCache.getChannelForClient(
         this.opt.clientId,

--- a/lib/irc.js
+++ b/lib/irc.js
@@ -374,10 +374,10 @@ function Client(server, nick, opt) {
                     util.log('NICK: ' + message.nick + ' changes nick to ' + message.args[0]);
 
                 // finding what channels a user is in
-                self.channelCache.getChannels(self.clientId).forEach((channel) => {
+                self.channelCache.getClientChannels(self.clientId).forEach((channel) => {
                     if (channel.userInChannel(message.nick)) {
                         channel.changeUserNick(message.nick, message.args[0]);
-                        channels.push(channame);
+                        channels.push(channel.serverName);
                     }
                 });
 

--- a/lib/irc.js
+++ b/lib/irc.js
@@ -136,6 +136,7 @@ function Client(server, nick, opt) {
         from,
         text,
         to;
+        const channels = [];
 
         switch (message.command) {
             case 'rpl_welcome':
@@ -372,8 +373,6 @@ function Client(server, nick, opt) {
                 if (self.opt.debug)
                     util.log('NICK: ' + message.nick + ' changes nick to ' + message.args[0]);
 
-                const channels = [];
-
                 // finding what channels a user is in
                 self.channelCache.getChannels(self.clientId).forEach((channel) => {
                     if (channel.userInChannel(message.nick)) {
@@ -590,7 +589,6 @@ function Client(server, nick, opt) {
                 break;
             case 'KILL':
                 nick = message.args[0];
-                channels = [];
                 this.opt.channelCache.getChannels(this.opt.clientId).forEach(function(channel) {
                     if (channel.userInChannel(nick)) {
                         channels.push(channel.key);
@@ -637,7 +635,6 @@ function Client(server, nick, opt) {
                 }
                 // handle other people quitting
 
-                channels = [];
 
                 // finding what channels a user is in?
                 this.opt.channelCache.getChannels(this.opt.clientId).forEach(function(channel) {

--- a/lib/irc.js
+++ b/lib/irc.js
@@ -422,13 +422,13 @@ function Client(server, nick, opt) {
                             }
                             if (knownPrefixes.length > 0) {
                                 channel.addUser(match[2]);
-                                channel.setUserMode(match[2], knownPrefixes);
+                                channel.setUserPrefix(match[2], knownPrefixes);
                             }
                             else {
                                 // recombine just in case this server allows weird chars in the nick.
                                 // We know it isn't a mode char.
                                 channel.addUser(match[1] + match[2]);
-                                channel.setUserMode(match[1] + match[2], "");
+                                channel.setUserPrefix(match[1] + match[2], "");
                             }
                         }
                     });


### PR DESCRIPTION
This will hopefully not be a breaking change so that existing apps can continue to run without issues, but any apps trying to spin up lots of IRC connections to the same network (hello ``matrix-appservice-irc``!) can pass in its own ChannelCache object and store information about each channel once rather than per client.

The cache has some protections in place which obviously cost some overhead, but the gains in not storing the same state per client should make up for it.

There are some pitfalls, however:
- Obviously, if different connections see different things for the same channel then the state get's mangled somewhat.
- Some extra memory footprint of storing the channels in sets and maps rather than straight up objects, but the hope is this will speed up trying to find or iterate an item.