### PR TITLE
Destroy existing socket before allocating a new one

### DIFF
--- a/lib/irc.js
+++ b/lib/irc.js
@@ -837,6 +837,10 @@ Client.prototype.connect = function(retryCount, callback) {
         };
     }
 
+    // destroy old socket before allocating a new one
+    if (self.conn !== null)
+        self.conn.destroy();
+
     // try to connect to the server
     if (self.opt.secure) {
         connectionOpts.rejectUnauthorized = !self.opt.selfSigned;


### PR DESCRIPTION
When reconnecting on timeout node-irc will create a new socket without properly destroying the old one. I have observed a race condition as a result of this that can hold multiple connections open at once. I can reliably reproduce this with [nandub/hubot-irc](https://github.com/nandub/hubot-irc). I can end up with as many open sockets as my retry limit.

Documentation for the destroy method [can be found here](https://nodejs.org/api/net.html#net_socket_destroy_exception).

I debated various other places to put this, but invoking it in connect() before allocating the connection seems like the safest place for all callers. This code is called from reconnect but could have other callers in the future.