### PR TITLE
change flawed opt merge for Object.assign

### DIFF
--- a/lib/irc.js
+++ b/lib/irc.js
@@ -30,9 +30,9 @@ exports.colors = colors;
 
 var lineDelimiter = new RegExp('\r\n|\r|\n')
 
-function Client(server, nick, opt) {
+function Client(server, nick, opt = {}) {
     var self = this;
-    self.opt = {
+    self.opt = { // default options
         server: server,
         nick: nick,
         password: null,
@@ -80,6 +80,9 @@ function Client(server, nick, opt) {
         }
     };
 
+    // Merge default options with user-supplied options
+    Object.assign(self.opt, opt)
+
     // Features supported by the server
     // (initial values are RFC 1459 defaults. Zeros signify
     // no default or unlimited value)
@@ -101,15 +104,6 @@ function Client(server, nick, opt) {
         usermodepriority: '', // E.g "ov"
         casemapping: 'ascii'
     };
-
-    if (typeof arguments[2] == 'object') {
-        var keys = Object.keys(self.opt);
-        for (var i = 0; i < keys.length; i++) {
-            var k = keys[i];
-            if (arguments[2][k] !== undefined)
-                self.opt[k] = arguments[2][k];
-        }
-    }
 
     if (self.opt.floodProtection) {
         self.activateFloodProtection();


### PR DESCRIPTION
This used to be an ad-hoc merge operation, which only works if your key already exists in the default options.
`Object.assign()` works way better