### PR TITLE
Add new option encoding_fallback to guess non-utf-8 encoding correctly.

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,8 +33,8 @@ The `node-irc` library isn't well maintained and there are a number of issues wh
  - Add function for getting channel modes.
  - Workaround terrible RFC3484 rules which means that IPv6 DNS rotations would not be honoured.
  - Add `setUserMode` to set a user's mode.
+ - Addition of `encodingFallback` option which allows setting encoding to use for non-UTF-8 encoded messages.
  - Addition of `onNickConflict()` option which is called on `err_nicknameinuse`. This function should return the next nick to try. The function defaults to suffixing monotonically increasing integers. Usage:
-
    ```javascript
    new Client("server.com", "MyNick", {
       onNickConflict: function() {

--- a/docs/API.rst
+++ b/docs/API.rst
@@ -35,7 +35,8 @@ Client
             stripColors: false,
             channelPrefixes: "&#",
             messageSplit: 512,
-            encoding: ''
+            encoding: '', 
+            encodingFallback: null,
         }
 
     `secure` (SSL connection) can be a true value or an object (the kind of object
@@ -68,6 +69,10 @@ Client
 
     With `encoding` you can set IRC bot to convert all messages to specified character set. If you don't want to use
     this just leave value blank or false. Example values are UTF-8, ISO-8859-15, etc.
+
+    With `encodingFallback` you can choose what encoding to use for non-UTF-8 messages.
+    Leave null for no fallback. Do not set `encoding` when using this as it assumes incoming
+    messages are UTF-8 OR fallback encoding.
 
     Setting `debug` to true will emit timestamped messages to the console
     using `util.log` when certain events are fired.

--- a/lib/irc.js
+++ b/lib/irc.js
@@ -22,6 +22,7 @@ const dns  = require('dns');
 const net  = require('net');
 const tls  = require('tls');
 const util = require('util');
+const isUtf8 = require('is-utf8');
 const { EventEmitter } = require('events');
 
 const colors = require('./colors');
@@ -67,6 +68,7 @@ function Client(server, nick, opt) {
         channelPrefixes: '&#',
         messageSplit: 512,
         encoding: false,
+        encodingFallback: null,
         onNickConflict: function(maxLen) { // maxLen may be undefined if not known
             if (typeof (self.opt.nickMod) == 'undefined')
                 self.opt.nickMod = 0;
@@ -905,10 +907,6 @@ Client.prototype.connect = function(retryCount, callback) {
     self.conn.requestedDisconnect = false;
     self.conn.setTimeout(1000 * 180);
 
-    if (!self.opt.encoding) {
-        self.conn.setEncoding('utf8');
-    }
-
     let buffer = Buffer.alloc(0);
 
     self.conn.addListener('data', function(chunk) {
@@ -1269,11 +1267,11 @@ Client.prototype.ctcp = function(to, type, text) {
 
 Client.prototype.convertEncoding = function(str) {
     var self = this, out = str;
+    const Iconv = require('iconv').Iconv;
 
     if (self.opt.encoding) {
         try {
             const detectCharset = require('detect-character-encoding');
-            const Iconv = require('iconv').Iconv;
             const charset = detectCharset(str);
             if (!charset) {
                 throw Error("No charset detected");
@@ -1284,6 +1282,18 @@ Client.prototype.convertEncoding = function(str) {
             if (self.opt.debug) {
                 util.log('\u001b[01;31mERROR: ' + err + '\u001b[0m');
                 util.inspect({ str: str, charset: charset });
+            }
+        }
+    } else if (self.opt.encodingFallback) {
+        try {
+            if (!isUtf8(str)) {
+                const converter = new Iconv(self.opt.encodingFallback, "UTF-8")
+                out = converter.convert(str)
+            }
+        } catch (err) {
+            if (self.opt.debug) {
+                util.log('\u001b[01;31mERROR: ' + err + '\u001b[0m');
+                util.inspect({ str: str, encodingFallback: self.opt.encodingFallback });
             }
         }
     }

--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
   "license": "GPL-3.0",
   "dependencies": {
     "irc-colors": "^1.1.0",
-    "rebuild": "^0.1.2"
+    "rebuild": "^0.1.2",
+    "is-utf8": "^0.2.1"
   },
   "optionalDependencies": {
     "iconv": "~2.3.4",


### PR DESCRIPTION
This is needed to implement recoding support for the IRC bridge.