### PR TITLE
there won't always be a space after `sasl` in CAP ACK

### DIFF
--- a/lib/irc.js
+++ b/lib/irc.js
@@ -660,7 +660,7 @@ function Client(server, nick, opt) {
             case 'CAP':
                 if (message.args[0] === '*' &&
                      message.args[1] === 'ACK' &&
-                     message.args[2] === 'sasl ') // there's a space after sasl
+                    message.args[2].split(' ').includes('sasl'))
                     self._send('AUTHENTICATE', 'PLAIN');
                 break;
             case 'AUTHENTICATE':


### PR DESCRIPTION
see #45