### PR TITLE
Replaced buggy is-utf8 with utf-8-validate library

### DIFF
--- a/lib/irc.js
+++ b/lib/irc.js
@@ -22,7 +22,7 @@ const dns  = require('dns');
 const net  = require('net');
 const tls  = require('tls');
 const util = require('util');
-const isUtf8 = require('is-utf8');
+const isValidUTF8 = require('utf-8-validate');
 const { EventEmitter } = require('events');
 
 const colors = require('./colors');
@@ -1286,8 +1286,8 @@ Client.prototype.convertEncoding = function(str) {
         }
     } else if (self.opt.encodingFallback) {
         try {
-            if (!isUtf8(str)) {
-                const converter = new Iconv(self.opt.encodingFallback, "UTF-8")
+            if (!isValidUTF8(str)) {
+                const converter = new Iconv(self.opt.encodingFallback[0], "UTF-8")
                 out = converter.convert(str)
             }
         } catch (err) {

--- a/lib/irc.js
+++ b/lib/irc.js
@@ -1287,7 +1287,7 @@ Client.prototype.convertEncoding = function(str) {
     } else if (self.opt.encodingFallback) {
         try {
             if (!isValidUTF8(str)) {
-                const converter = new Iconv(self.opt.encodingFallback[0], "UTF-8")
+                const converter = new Iconv(self.opt.encodingFallback, "UTF-8")
                 out = converter.convert(str)
             }
         } catch (err) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -717,6 +717,11 @@
       "integrity": "sha1-q8xsvT7C7Spyn/bnwfqPAXhKhXQ=",
       "dev": true
     },
+    "node-gyp-build": {
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-3.7.0.tgz",
+      "integrity": "sha512-L/Eg02Epx6Si2NXmedx+Okg+4UHqmaf3TNcxd50SF9NQGcJaON3AtU++kax69XV7YWz4tUspqZSAsVofhFKG2w=="
+    },
     "nomnom": {
       "version": "1.8.1",
       "resolved": "https://registry.npmjs.org/nomnom/-/nomnom-1.8.1.tgz",
@@ -1133,6 +1138,14 @@
       "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.6.0.tgz",
       "integrity": "sha1-izixDKze9jM3uLJOT/htRa6lKag=",
       "dev": true
+    },
+    "utf-8-validate": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/utf-8-validate/-/utf-8-validate-5.0.2.tgz",
+      "integrity": "sha512-SwV++i2gTD5qh2XqaPzBnNX88N6HdyhQrNNRykvcS0QKvItV9u3vPEJr+X5Hhfb1JC0r0e1alL0iB09rY8+nmw==",
+      "requires": {
+        "node-gyp-build": "~3.7.0"
+      }
     },
     "util-deprecate": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "dependencies": {
     "irc-colors": "^1.1.0",
     "rebuild": "^0.1.2",
-    "is-utf8": "^0.2.1"
+    "utf-8-validate": "^5.0.2"
   },
   "optionalDependencies": {
     "iconv": "~2.3.4",


### PR DESCRIPTION
This seems to fix issues with CTCP actions containing ASCII control codes. 

On my test setup there is no more false re-encoding for utf-8 actions like with is-utf8 library.
I suggest a new release to npm after this to get the fix usable in Matrix IRC bridge. At least
IRCnet bridge suffers from the encoding bugs.
