### PR TITLE
Make iconv dependency optional again.

### DIFF
--- a/lib/irc.js
+++ b/lib/irc.js
@@ -1277,7 +1277,6 @@ Client.prototype.ctcp = function(to, type, text) {
 
 Client.prototype.convertEncoding = function(str) {
     var self = this, out = str;
-    const Iconv = require('iconv').Iconv;
 
     if (self.opt.encoding) {
         try {
@@ -1286,6 +1285,7 @@ Client.prototype.convertEncoding = function(str) {
             if (!charset) {
                 throw Error("No charset detected");
             }
+            const Iconv = require('iconv').Iconv;
             const converter = new Iconv(charset.encoding, self.opt.encoding);
             out = converter.convert(str);
         } catch (err) {
@@ -1297,6 +1297,7 @@ Client.prototype.convertEncoding = function(str) {
     } else if (self.opt.encodingFallback) {
         try {
             if (!isValidUTF8(str)) {
+                const Iconv = require('iconv').Iconv;
                 const converter = new Iconv(self.opt.encodingFallback, "UTF-8")
                 out = converter.convert(str)
             }


### PR DESCRIPTION
Although `iconv` is listed in `optionalDependencies`, it's always required in `Client.prototype.convertEncoding` function in `lib/irc.js` file, even if neither `encoding` nor `encodingFallback` options are defined.

This error was introduced in 19daa5b2 when `require('iconv')` was erroneously moved to the top of that function to avoid code duplication.

This change makes `iconv` module not required again when `encoding` and `encodingFallback` options are not defined.