### PR TITLE
SASL CAP ACK doesn't always have *

### DIFF
--- a/lib/irc.js
+++ b/lib/irc.js
@@ -659,8 +659,7 @@ function Client(server, nick, opt) {
 
             // for sasl
             case 'CAP':
-                if (message.args[0] === '*' &&
-                    message.args[1] === 'ACK' &&
+                if (message.args[1] === 'ACK' &&
                     message.args[2].split(' ').includes('sasl'))
                     self._send('AUTHENTICATE', self.opt.saslType);
                 break;


### PR DESCRIPTION
As evidenced in the transcript below, a server doesn't necessarily send back `*` if you send `CAP REQ` before `NICK` (observed with inspircd / Atheme).

This seems to deadlock the connection.

```
:irc.server NOTICE Auth :*** Looking up your hostname...                                                                                                  
:irc.server NOTICE Auth :*** Could not resolve your hostname: Domain name not found; using your IP address 2a02:X) instead.                                                                                                                                                           
CAP REQ sasl                                                                                                                                                  
:irc.server CAP 663AAB8QI ACK :sasl                                                                                                                       
```