### PR TITLE
Allow ipv6 connections to servers

### DIFF
--- a/lib/irc.js
+++ b/lib/irc.js
@@ -47,7 +47,7 @@ function Client(server, nick, opt) {
         userName: 'nodebot',
         realName: 'nodeJS IRC client',
         port: 6667,
-        family: 4,
+        family: 0,
         bustRfc3484: false,
         localAddress: null,
         localPort: null,


### PR DESCRIPTION
It doesn't make sense to me to override the default from the socket library.
