### PR TITLE
Add fixtures for _splitLongLines with multi-byte characters

### DIFF
--- a/test/data/fixtures.json
+++ b/test/data/fixtures.json
@@ -201,6 +201,6 @@
             "input": "\ud83d\ude03\ud83d\ude03 ab abc",
             "maxLength": 5,
             "result": ["\ud83d\ude03", "\ud83d\ude03", "ab", "abc"]
-        },
+        }
     ]
 }

--- a/test/data/fixtures.json
+++ b/test/data/fixtures.json
@@ -176,6 +176,31 @@
             "input": "abc abcdef abc abcd abc",
             "maxLength": 5,
             "result": ["abc", "abcde", "f abc", "abcd", "abc"]
-        }
+        },
+        {
+            "input": "éé abc abc",
+            "maxLength": 5,
+            "result": ["éé", "abc", "abc"]
+        },
+        {
+            "input": "ééé ab abc",
+            "maxLength": 5,
+            "result": ["éé", "é ab", "abc"]
+        },
+        {
+            "input": "\ud83d\ude03 ab abc",
+            "maxLength": 5,
+            "result": ["\ud83d\ude03", "ab", "abc"]
+        },
+        {
+            "input": "abc\ud83d\ude03abc",
+            "maxLength": 5,
+            "result": ["abc", "\ud83d\ude03a", "bc"]
+        },
+        {
+            "input": "\ud83d\ude03\ud83d\ude03 ab abc",
+            "maxLength": 5,
+            "result": ["\ud83d\ude03", "\ud83d\ude03", "ab", "abc"]
+        },
     ]
 }


### PR DESCRIPTION
The only fixtures so far only checked single-byte characters;
and the code assumes IRC accepts 512 characters per lines, while
the protocol only accepts 512 bytes (and most servers will truncate
or truncate the message if it exceeds it).

This PR doesn't update the code, because I'm not familiar enough
with TS to do it, and it's tricky to implement properly.
So the CI will fail.