### PR TITLE
Send CAP END if not authenticating

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "matrix-org-irc",
   "description": "An IRC client library for node, written in Typescript.",
-  "version": "1.0.0-alpha2",
+  "version": "1.0.0-alpha3",
   "author": "Matrix.org (original fork from Martyn Smith <martyn@dollyfish.net.nz>)",
   "scripts": {
     "prepare": "npm run build",

--- a/src/irc.ts
+++ b/src/irc.ts
@@ -310,7 +310,9 @@ export class Client extends EventEmitter {
         }
 
         if (requiredCapabilites.length === 0) {
-            // Don't bother asking.
+            // Don't bother asking for any capabilities.
+            // We're finished checking for caps, so we can send an END.
+            this._send('CAP', 'END');
             return;
         }
         this.send('CAP REQ :', ...requiredCapabilites);
@@ -318,9 +320,11 @@ export class Client extends EventEmitter {
 
     private onCapsConfirmed() {
         if (!this.opt.sasl) {
-            // No need to do anything.
+            // We're not going to authenticate, so we can END.
+            this.send('CAP END');
             return;
         }
+        // otherwise, we should authenticate
         if (this.capabilities.supportsSaslMethod(this.opt.saslType, true)) {
             this._send('AUTHENTICATE', this.opt.saslType);
         }

--- a/src/irc.ts
+++ b/src/irc.ts
@@ -321,7 +321,7 @@ export class Client extends EventEmitter {
     private onCapsConfirmed() {
         if (!this.opt.sasl) {
             // We're not going to authenticate, so we can END.
-            this.send('CAP END');
+            this.send('CAP', 'END');
             return;
         }
         // otherwise, we should authenticate


### PR DESCRIPTION
We always need to send a CAP END once we're finished negotiations capabilities. There were a few places where we didn't do this. 