### PR TITLE
CAP LS should be sent before NICK and USER so that server knows we're going to attempt SASL authentication

### DIFF
--- a/src/irc.ts
+++ b/src/irc.ts
@@ -1082,13 +1082,13 @@ export class Client extends EventEmitter {
             this._send('PASS', this.opt.password);
         }
         if (this.opt.debug) {util.log('Sending irc NICK/USER');}
+        // Request capabilities.
+        // https://ircv3.net/specs/extensions/capability-negotiation.html
+        this._send('CAP LS', '302');
         this._send('NICK', this.nick);
         this.currentNick = this.nick;
         this._updateMaxLineLength();
         this._send('USER', this.opt.userName, '8', '*', this.opt.realName);
-        // Request capabilities.
-        // https://ircv3.net/specs/extensions/capability-negotiation.html
-        this._send('CAP LS', '302');
         this.emit('connect');
     }
 

--- a/test/data/fixtures.json
+++ b/test/data/fixtures.json
@@ -1,9 +1,9 @@
 {
 	"basic": {
 		"sent": [
+			["CAP LS 302", "Client sent CAP request"],
 			["NICK testbot", "Client sent NICK message"],
 			["USER nodebot 8 * :nodeJS IRC client", "Client sent USER message"],
-			["CAP LS 302", "Client sent CAP request"],
 			["QUIT :node-irc says goodbye", "Client sent QUIT message"]
 		],
 
@@ -13,9 +13,9 @@
 	},
 	"double-CRLF": {
 		"sent": [
+			["CAP LS 302", "Client sent CAP request"],
 			["NICK testbot", "Client sent NICK message"],
 			["USER nodebot 8 * :nodeJS IRC client", "Client sent USER message"],
-			["CAP LS 302", "Client sent CAP request"],
 			["QUIT :node-irc says goodbye", "Client sent QUIT message"]
 		],
 
@@ -134,9 +134,9 @@
 	},
 	"433-before-001": {
 		"sent": [
+			["CAP LS 302", "Client sent CAP request"],
 			["NICK testbot", "Client sent NICK message"],
 			["USER nodebot 8 * :nodeJS IRC client", "Client sent USER message"],
-			["CAP LS 302", "Client sent CAP request"],
 			["NICK testbot1", "Client sent proper response to 433 nickname in use message"],
 			["QUIT :node-irc says goodbye", "Client sent QUIT message"]
 		],


### PR DESCRIPTION
I noticed in matrix-org/matrix-appservice-irc#1353 that `irc.libera.chat` was rejecting connections from my bridge with `SASL access only`. After enabling `debug` for the IRC connection, I was able to see what commands were being sent to the server:

```
31 May 17:30:21 - Sending irc NICK/USER
31 May 17:30:21 - SEND: NICK melloc
31 May 17:30:21 - SEND: USER melloc 8 * @cody:timecube.club
31 May 17:30:21 - SEND: CAP LS 302
31 May 17:30:21 - GOT NOTICE from the server: "*** Notice -- You need to identify via SASL to use this server"
31 May 17:30:21 - Unhandled message: {
  args: [ 'Closing Link: timecube.club (SASL access only)' ],
  commandType: 'normal',
  command: 'ERROR',
  rawCommand: 'ERROR'
}
2021-05-31 17:30:21 ERROR:client-connection melloc@irc.libera.chat: {"args":["Closing Link: timecube.club (SASL access only)"],"commandType":"normal","command":"ERROR","rawCommand":"ERROR"}
2021-05-31 17:30:21 INFO:client-connection disconnect()ing melloc@irc.libera.chat - raw_error
31 May 17:30:21 - SEND: QUIT :node-irc says goodbye
31 May 17:30:21 - Connection got "end" event
2021-05-31 17:30:21 ERROR:client-connection ConnectionInstance.connect failed after 11 attempts (raw_error)
2021-05-31 17:30:21 INFO:client-connection Retrying connection for melloc on irc.libera.chat in 4691.1904349578135ms (attempts 11)
31 May 17:30:21 - Connection got "close" event
```

The examples for [capability negotiation](https://ircv3.net/specs/extensions/capability-negotiation.html) and [SASL authentication](https://ircv3.net/specs/extensions/sasl-3.2) show the `CAP LS` message being sent first, before `NICK` and `USER`. After locally modifying the client, I was able to connect and authenticate against `irc.libera.chat`, as well as continue connecting to and authenticating against `chat.freenode.net` and `irc.oftc.net`.

I ran `npm run lint` without any warnings:

```
cpm@nyx ~/src/node-irc : master % npm run lint

> matrix-org-irc@1.0.0-alpha4 lint /home/cpm/src/node-irc
> eslint -c .eslintrc --max-warnings 0 'src/**/*.ts'

```

I updated the tests to check for the new order, and ran `npm run test`:

```
cpm@nyx ~/src/node-irc : master % npm run test

> matrix-org-irc@1.0.0-alpha4 test /home/cpm/src/node-irc
> tap ./test/test-*.js

./test/test-433-before-001.js 1> 31 May 11:03:32 - Sending irc NICK/USER
./test/test-433-before-001.js 1> 31 May 11:03:32 - SEND: CAP LS 302
./test/test-433-before-001.js 1> 31 May 11:03:32 - SEND: NICK testbot
./test/test-433-before-001.js 1> 31 May 11:03:32 - SEND: USER nodebot 8 * :nodeJS IRC client
./test/test-433-before-001.js 1> 31 May 11:03:32 - SEND: NICK testbot1
./test/test-433-before-001.js 1> 31 May 11:03:32 - SEND: QUIT :node-irc says goodbye
./test/test-433-before-001.js 1> 31 May 11:03:32 - SEND: WHOIS testbot1
./test/test-433-before-001.js 1> 31 May 11:03:32 - Connection got "end" event
./test/test-433-before-001.js 1> 31 May 11:03:32 - Connection got "close" event
 PASS  ./test/test-433-before-001.js 10 OK 620.197ms
./test/test-auditorium.js 1> 31 May 11:03:32 - Sending irc NICK/USER
./test/test-auditorium.js 1> 31 May 11:03:32 - SEND: CAP LS 302
./test/test-auditorium.js 1> 31 May 11:03:32 - SEND: NICK testbot
./test/test-auditorium.js 1> 31 May 11:03:32 - SEND: USER nodebot 8 * :nodeJS IRC client
./test/test-auditorium.js 1> 31 May 11:03:32 - MODE: #auditorium sets mode: +o
./test/test-auditorium.js 1> 31 May 11:03:32 - SEND: QUIT :node-irc says goodbye
./test/test-auditorium.js 1> 31 May 11:03:32 - SEND: WHOIS testbot
./test/test-auditorium.js 1> 31 May 11:03:32 - Connection got "end" event
./test/test-auditorium.js 1> 31 May 11:03:32 - Connection got "close" event
 SKIP  ./test/test-auditorium.js 614.33ms
 SKIP  TAP
 ~ ./test/test-auditorium.js

./test/test-convert-encoding.js 2> Iconv-lite warning: decode()-ing strings is deprecated. Refer to https://github.com/ashtuchkin/iconv-lite/wiki/Use-Buffers-when-decoding
 PASS  ./test/test-convert-encoding.js 8 OK 563.426ms
./test/test-double-crlf.js 1> 31 May 11:03:34 - Sending irc NICK/USER
./test/test-double-crlf.js 1> 31 May 11:03:34 - SEND: CAP LS 302
./test/test-double-crlf.js 1> 31 May 11:03:34 - SEND: NICK testbot
./test/test-double-crlf.js 1> 31 May 11:03:34 - SEND: USER nodebot 8 * :nodeJS IRC client
./test/test-double-crlf.js 1> 31 May 11:03:34 - SEND: QUIT :node-irc says goodbye
./test/test-double-crlf.js 1> 31 May 11:03:34 - SEND: WHOIS testbot
./test/test-double-crlf.js 1> 31 May 11:03:34 - Connection got "end" event
./test/test-double-crlf.js 1> 31 May 11:03:34 - Connection got "close" event
 PASS  ./test/test-double-crlf.js 5 OK 602.175ms
./test/test-irc.js 1> 31 May 11:03:34 - Sending irc NICK/USER
./test/test-irc.js 1> 31 May 11:03:34 - SEND: CAP LS 302
./test/test-irc.js 1> 31 May 11:03:34 - SEND: NICK testbot
./test/test-irc.js 1> 31 May 11:03:34 - SEND: USER nodebot 8 * :nodeJS IRC client
./test/test-irc.js 1> 31 May 11:03:34 - SEND: QUIT :node-irc says goodbye
./test/test-irc.js 1> 31 May 11:03:34 - SEND: WHOIS testbot
./test/test-irc.js 1> 31 May 11:03:34 - Connection got "end" event
./test/test-irc.js 1> 31 May 11:03:34 - Connection got "close" event
./test/test-irc.js 1> 31 May 11:03:34 - Sending irc NICK/USER
./test/test-irc.js 1> 31 May 11:03:34 - SEND: CAP LS 302
./test/test-irc.js 1> 31 May 11:03:34 - SEND: NICK testbot
./test/test-irc.js 1> 31 May 11:03:34 - SEND: USER nodebot 8 * :nodeJS IRC client
./test/test-irc.js 1> 31 May 11:03:34 - SEND: QUIT :node-irc says goodbye
./test/test-irc.js 1> 31 May 11:03:34 - SEND: WHOIS testbot
./test/test-irc.js 1> 31 May 11:03:34 - Connection got "end" event
./test/test-irc.js 1> 31 May 11:03:34 - Connection got "close" event
./test/test-irc.js 1> 31 May 11:03:34 - Sending irc NICK/USER
./test/test-irc.js 1> 31 May 11:03:34 - SEND: CAP LS 302
./test/test-irc.js 1> 31 May 11:03:34 - SEND: NICK testbot
./test/test-irc.js 1> 31 May 11:03:34 - SEND: USER nodebot 8 * :nodeJS IRC client
./test/test-irc.js 1> 31 May 11:03:34 - SEND: QUIT :node-irc says goodbye
./test/test-irc.js 1> 31 May 11:03:34 - SEND: WHOIS testbot
./test/test-irc.js 1> 31 May 11:03:34 - Connection got "end" event
./test/test-irc.js 1> 31 May 11:03:34 - Connection got "close" event
 PASS  ./test/test-irc.js 15 OK 732.678ms
 PASS  ./test/test-parse-line.js 11 OK 504.873ms

                         
  🌈 SUMMARY RESULTS 🌈  
                         

 SKIP  ./test/test-auditorium.js 614.33ms
Suites:   5 passed, 1 skip, 6 of 6 completed
Asserts:  49 passed, 1 skip, of 50
Time:     4s
------------------|---------|----------|---------|---------|----------------------------------------------------------------------------------------------------------
File              | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s
------------------|---------|----------|---------|---------|----------------------------------------------------------------------------------------------------------
All files         |   32.93 |    23.82 |   28.57 |   33.29 |                                                                                                         
 capabilities.ts  |   10.71 |        0 |    12.5 |   11.11 | 14-22,35-87                                                                                             
 codes.ts         |     100 |      100 |     100 |     100 |                                                                                                         
 irc.ts           |   32.72 |    22.63 |    29.7 |   33.14 | ...7,1322-1327,1342,1361-1458,1464-1466,1481-1549,1558,1563-1565,1570-1578,1597,1606,1610,1617,1633-1637
 parse_message.ts |   97.14 |    85.71 |     100 |   96.97 | 67                                                                                                      
 splitLines.ts    |       2 |        0 |       0 |    2.13 | 2-9,16-89                                                                                               
------------------|---------|----------|---------|---------|----------------------------------------------------------------------------------------------------------
```

Let me know if there's anything else I should do to help get this merged.