### PR TITLE
Handle RPL_WHOISACTUALLY

### DIFF
--- a/src/codes.ts
+++ b/src/codes.ts
@@ -249,6 +249,10 @@ export const replyCodes = {
         name: 'rpl_topicwhotime',
         type: 'reply'
     },
+    338: {
+        name: 'rpl_whoisactually',
+        type: 'reply'
+    },
     341: {
         name: 'rpl_inviting',
         type: 'reply'

--- a/src/irc.ts
+++ b/src/irc.ts
@@ -61,6 +61,7 @@ export interface WhoisResponse {
     operator?: string;
     account?: string;
     accountinfo?: string;
+    realHost?: string;
 }
 
 export interface IrcClientOpts {
@@ -955,6 +956,8 @@ export class Client extends EventEmitter {
             case 'rpl_whoisserver':
                 this._addWhoisData(message.args[1], 'server', message.args[2]);
                 return this._addWhoisData(message.args[1], 'serverinfo', message.args[3]);
+            case 'rpl_whoisactually':
+                return this._addWhoisData(message.args[1], 'realHost', message.args[2]);
             case 'rpl_whoisoperator':
                 return this._addWhoisData(message.args[1], 'operator', message.args[2]);
             case 'rpl_whoisaccount':


### PR DESCRIPTION
Solanum (Libera) and other ircds send the 338 numeric
(RPL_WHOISACTUALLY) on some WHOIS replies, including your own. It's not
super useful but it does give the underlying IP address.

Signed-off-by: Emerson Veenstra <git@emersonveenstra.net>