### PR TITLE
Fix when 'registered' is emitted

### DIFF
--- a/changelog.d/75.bugfix
+++ b/changelog.d/75.bugfix
@@ -1,0 +1,1 @@
+Fix when 'registered' is emitted

--- a/src/irc.ts
+++ b/src/irc.ts
@@ -352,10 +352,7 @@ export class Client extends EventEmitter {
         const welcomeStringWords = message.args[1].split(/\s+/);
         this.hostMask = welcomeStringWords[welcomeStringWords.length - 1];
         this._updateMaxLineLength();
-        if (!this.opt.sasl) {
-            // If this connection is using SASL, we don't want to emit this until they are authenticated.
-            this.emit('registered');
-        }
+        this.emit('registered');
         this.whois(this.currentNick, (args) => {
             if (!args) {
                 // TODO: We can't find our own nick, so do nothing here.
@@ -1018,11 +1015,9 @@ export class Client extends EventEmitter {
             case 'err_saslaborted':
             case 'err_saslalready':
                 this.emit('sasl_error', message.command, ...message.args);
-                this.emit('registered'); // emit on failed OR
                 // We're not going to retry on this connection, so end it.
                 return this._send('CAP', 'END');
             case 'rpl_saslsuccess':
-                this.emit('registered'); // emit on success
                 return this._send('CAP', 'END');
             case 'err_unavailresource':
             // err_unavailresource has been seen in the wild on Freenode when trying to


### PR DESCRIPTION
Don't emit registered on SASL replies, because the nick may not be
correct. Also always emit registered on RPL_WELCOME, because that
will only be sent after CAP END anyways. Fixes #74.

Signed off by Emerson Veenstra <git@emersonveenstra.net>