### PR TITLE
Fix tokenization

### DIFF
--- a/changelog.d/87.bug
+++ b/changelog.d/87.bug
@@ -1,0 +1,1 @@
+Fix tokenization to ignore non-ASCII-space whitespaces

--- a/src/parse_message.ts
+++ b/src/parse_message.ts
@@ -61,8 +61,8 @@ export function parseMessage(line: string, stripColors: boolean): Message {
     let middle, trailing;
 
     // Parse parameters
-    if (line.search(/^:|\s+:/) !== -1) {
-        match = line.match(/(.*?)(?:^:|\s+:)(.*)/);
+    if (line.search(/^:| +:/) !== -1) {
+        match = line.match(/(.*?)(?:^:| +:)(.*)/);
         if (!match) {
             throw Error('Invalid format, could not parse parameters');
         }


### PR DESCRIPTION
Whitespaces other than the ASCII space are technically valid in a token;
and some servers (eg. some InspIRCd configs, as well as Hybrid) allow them
in channel names.

This means, for example, that the command
`KICK #channel\u00a0:test nickname :reason` was parsed as
`[command: "KICK", args: ["#channel", "test nickname :reason"]}`
instead of
`[command: "KICK", args: ["#channel\u00a0:test", "nickname", "reason"]}`