### PR TITLE
Disable rejectUnauthorized if expired certificates are allowed

### DIFF
--- a/changelog.d/90.bugfix
+++ b/changelog.d/90.bugfix
@@ -1,0 +1,1 @@
+Prevent connection immediately terminating on expired certificate when allowed by config. Contributed by @f0x52.

--- a/src/irc.ts
+++ b/src/irc.ts
@@ -1168,7 +1168,7 @@ export class Client extends EventEmitter {
         if (this.opt.secure) {
             let secureOpts: tls.ConnectionOptions = {
                 ...connectionOpts,
-                rejectUnauthorized: !this.opt.selfSigned,
+                rejectUnauthorized: !(this.opt.selfSigned || this.opt.certExpired),
             }
 
             if (typeof this.opt.secure === 'object') {


### PR DESCRIPTION
if rejectUnauthorized is not disabled for `this.opt.certExpired = true`, the socket is already closed before the case on line 1201 can choose to keep the socket open anyways.