### PR TITLE
Try using ergochat for CI testing

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -40,10 +40,7 @@ jobs:
     timeout-minutes: 10
     services:
       ircd:
-        image: inspircd/inspircd-docker
-        env:
-          # Don't check domain against blacklists
-          INSP_ENABLE_DNSBL: no
+        image: ghcr.io/ergochat/ergo:stable
         ports:
           - 6667:6667
     strategy:

--- a/changelog.d/101.misc
+++ b/changelog.d/101.misc
@@ -1,0 +1,1 @@
+Use ergo as our ircd of choice for automated testing.


### PR DESCRIPTION
Inspircd is a bit of a pain to modify the config of in GHA, and the defaults just ban our test rig outright. Ergo supports setting env flags so we can modify it if we need to.