### PR TITLE
Fix: this.state.chans and channel.users are Map type, not an Object type

### DIFF
--- a/changelog.d/103.bugfix
+++ b/changelog.d/103.bugfix
@@ -1,2 +1,3 @@
 Users that quit IRC network now leave Matrix channel properly.
 Users that are killed from IRC network now leave Matrix channel properly.
+It also fixes nick changes: old nick leaves Matrix room and new nick joins Matrix room.

--- a/changelog.d/103.bugfix
+++ b/changelog.d/103.bugfix
@@ -1,0 +1,2 @@
+Users that quit IRC network now leave Matrix channel properly.
+Users that are killed from IRC network now leave Matrix channel properly.

--- a/src/irc.ts
+++ b/src/irc.ts
@@ -619,8 +619,9 @@ export class Client extends (EventEmitter as unknown as new () => TypedEmitter<C
 
         // finding what channels a user is in
         this.state.chans.forEach((nickChannel, channame) => {
-            if (message.nick && nickChannel.users.has(message.nick)) {
-                nickChannel.users.set(message.args[0], nickChannel.users.get(message.nick));
+            const chanUser = message.nick && nickChannel.users.get(message.nick);
+            if (message.nick && chanUser) {
+                nickChannel.users.set(message.args[0], chanUser);
                 nickChannel.users.delete(message.nick);
                 channelsForNick.push(channame);
             }

--- a/src/irc.ts
+++ b/src/irc.ts
@@ -846,9 +846,9 @@ export class Client extends (EventEmitter as unknown as new () => TypedEmitter<C
     private onKill(message: Message) {
         const nick = message.args[0];
         const killChannels = [];
-        for (const [channame, killChannel] of Object.entries(this.state.chans)) {
-            if (message.nick && message.nick in killChannel.users) {
-                delete killChannel.users[message.nick];
+        for (const [channame, killChannel] of this.state.chans.entries()) {
+            if (message.nick && killChannel.users.has(message.nick)) {
+                killChannel.users.delete(message.nick);
                 killChannels.push(channame);
             }
         }
@@ -908,9 +908,9 @@ export class Client extends (EventEmitter as unknown as new () => TypedEmitter<C
         const quitChannels: string[] = [];
 
         // finding what channels a user is in?
-        for (const [channame, quitChannel] of Object.entries(this.state.chans)) {
-            if (message.nick && message.nick in quitChannel.users) {
-                delete quitChannel.users[message.nick];
+        for (const [channame, quitChannel] of this.state.chans.entries()) {
+            if (message.nick && quitChannel.users.has(message.nick)) {
+                quitChannel.users.delete(message.nick);
                 quitChannels.push(channame);
             }
         }

--- a/src/irc.ts
+++ b/src/irc.ts
@@ -618,10 +618,9 @@ export class Client extends (EventEmitter as unknown as new () => TypedEmitter<C
         const channelsForNick: string[] = [];
 
         // finding what channels a user is in
-        Object.entries(this.state.chans).forEach(([channame, nickChannel]) => {
-            const chanUser = message.nick && nickChannel.users.get(message.nick);
-            if (message.nick && chanUser) {
-                nickChannel.users.set(message.args[0], chanUser);
+        this.state.chans.forEach((nickChannel, channame) => {
+            if (message.nick && nickChannel.users.has(message.nick)) {
+                nickChannel.users.set(message.args[0], nickChannel.users.get(message.nick));
                 nickChannel.users.delete(message.nick);
                 channelsForNick.push(channame);
             }


### PR DESCRIPTION
- Object.entries(this.state.chans) is not working as it is a Map, it returns an empty array.
- message.nick in killChannel.users is not working as it is a Map too. Repacing with Map.prototype.has().
- Replacing delete killChannel.users[message.nick] with Map.prototype.delete().
- Doing the same with quitChannel.