### PR TITLE
Handle error 415 (+R/+M)

### DIFF
--- a/src/codes.ts
+++ b/src/codes.ts
@@ -397,6 +397,13 @@ export const replyCodes = {
         name: 'err_wildtoplevel',
         type: 'error'
     },
+    // Used in oftc-hybrid-1.7.3 and Solanum.
+    // Returned when a channel requires its users to have a NickServ account to 
+    // talk.
+    415: {
+        name: 'err_needreggednick',
+        type: 'error'
+    },
     421: {
         name: 'err_unknowncommand',
         type: 'error'


### PR DESCRIPTION
This is returned in channels set +R (solanum) or +M (oftc-hybrid), which doesn't let unidentified users to talk.