### PR TITLE
Fix reconnect loop

### DIFF
--- a/changelog.d/115.bugfix
+++ b/changelog.d/115.bugfix
@@ -1,1 +1,1 @@
-Fix reconnect loop due to the close listener being called on socket destruction
+Fix reconnect loop due to the close listener being called on socket destruction.

--- a/changelog.d/115.bugfix
+++ b/changelog.d/115.bugfix
@@ -1,0 +1,1 @@
+Fix reconnect loop due to the close listener being called on socket destruction

--- a/src/irc.ts
+++ b/src/irc.ts
@@ -1272,6 +1272,12 @@ export class Client extends (EventEmitter as unknown as new () => TypedEmitter<C
 
         // destroy old socket before allocating a new one
         if (this.isOurSocket && this.conn) {
+            // The 'close' listener is called when the socket is destroyed, which
+            // initiates another reconnect attempt. This reconnect attempt disconnects
+            // the new connection created by this control flow after the `retryDelay`.
+            // To avoid an endless reconnect loop, we need to remove the 'close'
+            // listener here before destroying the socket.
+            this.conn.removeAllListeners('close');
             this.conn.destroy();
             this.conn = undefined;
         }

--- a/src/irc.ts
+++ b/src/irc.ts
@@ -1272,12 +1272,7 @@ export class Client extends (EventEmitter as unknown as new () => TypedEmitter<C
 
         // destroy old socket before allocating a new one
         if (this.isOurSocket && this.conn) {
-            // The 'close' listener is called when the socket is destroyed, which
-            // initiates another reconnect attempt. This reconnect attempt disconnects
-            // the new connection created by this control flow after the `retryDelay`.
-            // To avoid an endless reconnect loop, we need to remove the 'close'
-            // listener here before destroying the socket.
-            this.conn.removeAllListeners('close');
+            this.unbindListeners();
             this.conn.destroy();
             this.conn = undefined;
         }
@@ -1431,6 +1426,14 @@ export class Client extends (EventEmitter as unknown as new () => TypedEmitter<C
         });
     }
 
+    private unbindListeners() {
+        (
+            ['data', 'end', 'close', 'timeout', 'error'] as (keyof IrcConnectionEventsMap)[]
+        ).forEach(evtType => {
+            this.conn?.removeAllListeners(evtType);
+        });
+    }
+
     private reconnect(retryCount: number) {
         if (!this.isOurSocket) {
             // Cannot reconnect if the socket is not ours.
@@ -1461,11 +1464,7 @@ export class Client extends (EventEmitter as unknown as new () => TypedEmitter<C
      */
     public destroy() {
         util.log('Destroying connection');
-        (
-            ['data', 'end', 'close', 'timeout', 'error'] as (keyof IrcConnectionEventsMap)[]
-        ).forEach(evtType => {
-            this.conn?.removeAllListeners(evtType);
-        });
+        this.unbindListeners();
         if (this.isOurSocket) {
             this.disconnect();
         }


### PR DESCRIPTION
The `close` listener is called when the socket is destroyed, which initiates another reconnect attempt. This reconnect attempt disconnects the new connection created by this control flow after the `retryDelay`. To avoid an endless reconnect loop, we need to remove the `close` listener here before destroying the socket.

Fix #96

<!--
Hi there 👋, please check you've read the [CONTRIBUTING](../CONTRIBUTING.md) guide before submitting a PR (it's worth it, honest).
-->