### PR TITLE
Fix capabilities event listener

### DIFF
--- a/changelog.d/116.bugfix
+++ b/changelog.d/116.bugfix
@@ -1,1 +1,1 @@
-Fix auto reconnect due to event listeners not being called
+Fix auto reconnect due to event listeners not being called.

--- a/changelog.d/116.bugfix
+++ b/changelog.d/116.bugfix
@@ -1,0 +1,1 @@
+Fix auto reconnect due to event listeners not being called

--- a/src/irc.ts
+++ b/src/irc.ts
@@ -219,12 +219,12 @@ export class Client extends (EventEmitter as unknown as new () => TypedEmitter<C
         if (opt.channelPrefixes) {
             this.state.supportedState.channel.types = opt.channelPrefixes;
         }
-        this.state.capabilities.once('serverCapabilitesReady', () => {
+        this.state.capabilities.on('serverCapabilitesReady', () => {
             this.onCapsList();
             // Flush on capabilities modified
             this.state.flush?.();
         })
-        this.state.capabilities.once('userCapabilitesReady', () => {
+        this.state.capabilities.on('userCapabilitesReady', () => {
             this.onCapsConfirmed();
             // Flush on capabilities modified
             this.state.flush?.();


### PR DESCRIPTION
Using `once` here prevents the listeners from being called again after a reconnect, thus preventing successful reconnection.

<!--
Hi there 👋, please check you've read the [CONTRIBUTING](../CONTRIBUTING.md) guide before submitting a PR (it's worth it, honest).
-->