### PR TITLE
Fix chanlist in nick change events

### DIFF
--- a/changelog.d/117.bugfix
+++ b/changelog.d/117.bugfix
@@ -1,0 +1,1 @@
+Fix nick changes not being bridged to matrix

--- a/changelog.d/117.bugfix
+++ b/changelog.d/117.bugfix
@@ -1,1 +1,1 @@
-Fix nick changes not being bridged to matrix
+Fix nick changes not being bridged to matrix.

--- a/src/irc.ts
+++ b/src/irc.ts
@@ -630,9 +630,8 @@ export class Client extends (EventEmitter as unknown as new () => TypedEmitter<C
 
         // finding what channels a user is in
         this.state.chans.forEach((nickChannel, channame) => {
-            const chanUser = message.nick && nickChannel.users.get(message.nick);
-            if (message.nick && chanUser) {
-                nickChannel.users.set(message.args[0], chanUser);
+            if (message.nick && nickChannel.users.has(message.nick)) {
+                nickChannel.users.set(message.args[0], nickChannel.users.get(message.nick));
                 nickChannel.users.delete(message.nick);
                 channelsForNick.push(channame);
             }

--- a/src/irc.ts
+++ b/src/irc.ts
@@ -631,7 +631,7 @@ export class Client extends (EventEmitter as unknown as new () => TypedEmitter<C
         // finding what channels a user is in
         this.state.chans.forEach((nickChannel, channame) => {
             if (message.nick && nickChannel.users.has(message.nick)) {
-                nickChannel.users.set(message.args[0], nickChannel.users.get(message.nick));
+                nickChannel.users.set(message.args[0], nickChannel.users.get(message.nick)!);
                 nickChannel.users.delete(message.nick);
                 channelsForNick.push(channame);
             }


### PR DESCRIPTION
This fixes nick changes not being bridged to matrix, due to the chanlist being empty in nick change events.

Fix https://github.com/matrix-org/matrix-appservice-irc/issues/1776