### PR TITLE
Ensure channel.users is an accurate representation of the NAMES response after updating by removing stale users

### DIFF
--- a/changelog.d/118.bugfix
+++ b/changelog.d/118.bugfix
@@ -1,0 +1,1 @@
+Ensure channel.users is an accurate representation of the NAMES response after updates, removing stale users.

--- a/src/state.ts
+++ b/src/state.ts
@@ -90,6 +90,7 @@ export interface ChanData {
      * nick => mode
      */
     users: Map<string, string>,
+    tmpUsers: Map<string, string>, // used while processing NAMES replies
     mode: string;
     modeParams: Map<string, string[]>,
     topic?: string;


### PR DESCRIPTION
https://github.com/matrix-org/node-irc/blob/master/src/irc.ts#L660
When parsing responses to the `NAMES` command, (changes to) users are only ever `set` on the `channel.users` Map. This causes the `channel.users` list to perpetually keep growing as new users join, but never remove entries from users that have since left.

`onPart()` does remove entries, which works most of the time, but it seems these can be missed, most likely due to netsplits.

This fix keeps a separate Map (`tmpUsers`) where usernames + modes are stored as they come in through `onReplyName()`. In `onReplyNameEnd()` the old userlist is cleared, the new entries are copied over (so only the users in the NAMES response remain), and the tmpUsers Map is cleared so it can be used for the next `NAMES` block.

Found this while debugging why the Matrix side of many bridged rooms has many more IRC users than the IRC side.
